### PR TITLE
[C-2527] adds preference widget component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,6 +20,7 @@
     "@trycourier/react-inbox": "^0.1.10-alpha.27",
     "@trycourier/react-provider": "^0.1.10-alpha.27",
     "@trycourier/react-toast": "^0.1.10-alpha.27",
+    "@trycourier/react-preferences": "^0.1.10-alpha.27",
     "babel-loader": "^8.0.6",
     "camel-case": "^4.1.2",
     "html-webpack-plugin": "^3.2.0",

--- a/packages/react-preferences/README.md
+++ b/packages/react-preferences/README.md
@@ -1,0 +1,12 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [What is Preferences?](#what-is-preferences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<a name="1overviewmd"></a>
+
+## What is Preferences?
+
+A set of UI components that takes care of managing the notification preferences of your end-users.

--- a/packages/react-preferences/babel.config.js
+++ b/packages/react-preferences/babel.config.js
@@ -1,0 +1,29 @@
+module.exports = {
+  sourceType: "unambiguous",
+  plugins: [
+    "inline-react-svg",
+    "@babel/transform-runtime",
+    "babel-plugin-styled-components",
+    "transform-class-properties",
+    [
+      "babel-plugin-inline-import",
+      {
+        extensions: [".css"],
+      },
+    ],
+    ["babel-plugin-react-remove-properties", { properties: ["data-testid"] }],
+    process.env.NODE_ENV !== "test" && [
+      "babel-plugin-root-import",
+      {
+        rootPathSuffix: "./src",
+        rootPathPrefix: "~/",
+      },
+    ],
+  ].filter(Boolean),
+  presets: [
+    "@babel/preset-typescript",
+    "@babel/preset-env",
+    "@babel/preset-react",
+  ],
+  ignore: ["src/__tests__", "src/__mocks__"],
+};

--- a/packages/react-preferences/docs/1.overview.md
+++ b/packages/react-preferences/docs/1.overview.md
@@ -1,0 +1,3 @@
+## What is Preferences?
+
+A set of UI components that takes care of managing the notification preferences of your end-users.

--- a/packages/react-preferences/package.json
+++ b/packages/react-preferences/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/react-preferences",
-  "version": "0.0.1-alpha",
+  "version": "0.1.10-alpha.27",
   "main": "dist/index.js",
   "types": "typings/index.d.ts",
   "scripts": {

--- a/packages/react-preferences/package.json
+++ b/packages/react-preferences/package.json
@@ -8,6 +8,7 @@
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
     "clean": "rimraf dist",
+    "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "test": "jest -c jest.config.js --runInBand --silent",
     "type-check": "tsc --noEmit",
     "types": "rimraf typings && tsc --declaration --outDir typings/ --emitDeclarationOnly --declarationMap --allowJs false --checkJs false"

--- a/packages/react-preferences/package.json
+++ b/packages/react-preferences/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@trycourier/react-preferences",
+  "version": "0.0.1-alpha",
+  "main": "dist/index.js",
+  "types": "typings/index.d.ts",
+  "scripts": {
+    "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
+    "build:watch": "yarn babel --watch",
+    "build": "rimraf dist && yarn babel",
+    "clean": "rimraf dist",
+    "test": "jest -c jest.config.js --runInBand --silent",
+    "type-check": "tsc --noEmit",
+    "types": "rimraf typings && tsc --declaration --outDir typings/ --emitDeclarationOnly --declarationMap --allowJs false --checkJs false"
+  },
+  "peerDependencies": {
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "react-toggle": "^4.1.2"
+  }
+}

--- a/packages/react-preferences/src/components/ChannelPreferences.tsx
+++ b/packages/react-preferences/src/components/ChannelPreferences.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { PreferenceItemComponentFn } from "./types";
+
+// TODO
+export const ChannelPreferences: PreferenceItemComponentFn = () => <></>;

--- a/packages/react-preferences/src/components/SnoozePreference.tsx
+++ b/packages/react-preferences/src/components/SnoozePreference.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+import { PreferenceItemComponentFn } from "./types";
+
+// TODO
+export const SnoozePreference: PreferenceItemComponentFn = () => <></>;

--- a/packages/react-preferences/src/components/Status.tsx
+++ b/packages/react-preferences/src/components/Status.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Toggle from "react-toggle";
+import { PreferenceItemComponentFn } from "./types";
+import { StyledToggle } from "./StyledToggle";
+
+export const StatusPreference: PreferenceItemComponentFn = ({
+  label,
+  value = "OPTED_IN",
+  handleOnPreferenceChange,
+}) => {
+  function onToggleStatusChange() {
+    const toggledValue = value === "OPTED_IN" ? "OPTED_OUT" : "OPTED_IN";
+    handleOnPreferenceChange(toggledValue);
+  }
+  return (
+    <StyledToggle>
+      <label>
+        <span>{label}</span>
+        <Toggle
+          icons={false}
+          checked={value === "OPTED_IN" ? true : false}
+          value={value}
+          onChange={onToggleStatusChange}
+        />
+      </label>
+    </StyledToggle>
+  );
+};

--- a/packages/react-preferences/src/components/StyledToggle.tsx
+++ b/packages/react-preferences/src/components/StyledToggle.tsx
@@ -1,0 +1,113 @@
+import styled from "styled-components";
+
+export const StyledToggle = styled.div`
+  height: 16px;
+
+  label {
+    margin: 0;
+  }
+
+  .react-toggle {
+    touch-action: pan-x;
+
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+
+    user-select: none;
+
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .react-toggle-screenreader-only {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
+
+  .react-toggle--disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    transition: opacity 0.25s;
+  }
+
+  .react-toggle-track {
+    width: 30px;
+    height: 16px;
+    padding: 0;
+    border-radius: 30px;
+    background-color: #344563;
+    transition: all 0.2s ease;
+  }
+
+  .react-toggle--checked .react-toggle-track {
+    background-color: #9d3789;
+  }
+
+  .react-toggle-track-check {
+    position: absolute;
+    width: 14px;
+    height: 10px;
+    top: 0px;
+    bottom: 0px;
+    margin-top: auto;
+    margin-bottom: auto;
+    line-height: 0;
+    left: 8px;
+    opacity: 0;
+    transition: opacity 0.25s ease;
+  }
+
+  .react-toggle--checked .react-toggle-track-check {
+    opacity: 1;
+    transition: opacity 0.25s ease;
+  }
+
+  .react-toggle-track-x {
+    display: none;
+  }
+
+  .react-toggle-thumb {
+    transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
+    position: absolute;
+    top: 2px;
+    left: 3px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: #fafafa;
+    box-sizing: border-box;
+    transition: all 0.25s ease;
+  }
+
+  .react-toggle--checked .react-toggle-thumb {
+    left: 15px;
+  }
+
+  .react-toggle--focus .react-toggle-thumb {
+    box-shadow: 0px 0px 2px 3px #0099e0;
+  }
+
+  .react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb {
+    box-shadow: 0px 0px 5px 5px #0099e0;
+  }
+  label {
+    display: flex;
+    width: 100%;
+    span {
+      width: 80%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  }
+`;

--- a/packages/react-preferences/src/components/index.ts
+++ b/packages/react-preferences/src/components/index.ts
@@ -1,0 +1,1 @@
+export { Preferences } from "./preferences";

--- a/packages/react-preferences/src/components/preferences.tsx
+++ b/packages/react-preferences/src/components/preferences.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import {
+  IPreferenceTemplate,
+  usePreferenceTemplate,
+} from "../hooks/use-preferences";
+import { ChannelPreferences } from "./ChannelPreferences";
+import { SnoozePreference } from "./SnoozePreference";
+import { StatusPreference } from "./Status";
+import { Preference, PreferenceItemComponentFn } from "./types";
+
+const COURIER_SUPPORTED_PREFERENCES: Record<
+  Preference,
+  PreferenceItemComponentFn
+> = {
+  channel_preferences: ChannelPreferences,
+  snooze: SnoozePreference,
+  status: StatusPreference,
+};
+
+export const Preferences: React.FunctionComponent<{
+  preferenceTemplateId: string;
+}> = ({ preferenceTemplateId }) => {
+  const [preferenceGroup, updatePreferenceGroup] = usePreferenceTemplate(
+    preferenceTemplateId
+  );
+
+  if (!preferenceGroup) {
+    return null;
+  }
+
+  const handleOnPreferenceChange = (
+    changedIndex: number,
+    changes: string | string[]
+  ) => {
+    const preferences = [...(preferenceGroup?.templateItems ?? [])];
+
+    const updatedPreferences = {
+      ...preferenceGroup,
+      templateItems: [
+        ...preferences.slice(0, changedIndex),
+        {
+          ...preferences[changedIndex],
+          itemValue: changes,
+        },
+        ...preferences.slice(changedIndex + 1),
+      ],
+    } as IPreferenceTemplate;
+
+    updatePreferenceGroup(updatedPreferences);
+  };
+
+  return (
+    <>
+      <h4>{preferenceGroup?.templateName}</h4>
+      {preferenceGroup.templateItems.map((item, index) => {
+        const PreferenceItem = COURIER_SUPPORTED_PREFERENCES[item.type];
+        const handleOnPreferenceChangeForIndex = handleOnPreferenceChange.bind(
+          null,
+          index
+        );
+        return (
+          <PreferenceItem
+            key={index}
+            label={item.itemName}
+            value={item?.itemValue}
+            handleOnPreferenceChange={handleOnPreferenceChangeForIndex}
+          />
+        );
+      })}
+    </>
+  );
+};

--- a/packages/react-preferences/src/components/types.ts
+++ b/packages/react-preferences/src/components/types.ts
@@ -1,0 +1,7 @@
+export type Preference = "channel_preferences" | "status" | "snooze";
+
+export type PreferenceItemComponentFn = React.FunctionComponent<{
+  label: string;
+  value: string | string[];
+  handleOnPreferenceChange: (changes: string | string[]) => void;
+}>;

--- a/packages/react-preferences/src/hooks/use-preferences.ts
+++ b/packages/react-preferences/src/hooks/use-preferences.ts
@@ -1,0 +1,67 @@
+import { CourierContext, ICourierContext } from "@trycourier/react-provider";
+import { useContext, useEffect, useState } from "react";
+import { OperationResult } from "urql";
+
+const GET_PREFRENCE_TEMPLATE = `
+  query($id: String!) {
+    preferenceTemplate(id: $id) {
+      templateName
+      templateItems {
+        itemName
+        type
+      }
+      templateName
+    }
+  }
+`;
+export interface IPreferenceRule {
+  itemName: string;
+  itemValue: string | string[];
+  type: "snooze" | "channel_preferences" | "status";
+}
+
+export interface IPreferenceTemplate {
+  templateName: string;
+  templateId?: string;
+  templateItems: IPreferenceRule[];
+}
+
+export const usePreferenceTemplate = (
+  templateId: string
+): [
+  IPreferenceTemplate | undefined,
+  (preferenceGrouping: IPreferenceTemplate) => Promise<void>
+] => {
+  const [preferenceTemplate, setPreferenceTemplate] = useState<
+    IPreferenceTemplate | undefined
+  >(undefined);
+
+  const context = useContext<ICourierContext | undefined>(CourierContext);
+
+  useEffect(() => {
+    context?.graphQLClient
+      ?.query(GET_PREFRENCE_TEMPLATE, {
+        id: templateId,
+      })
+      ?.then(
+        (
+          response: OperationResult<
+            { preferenceTemplate: IPreferenceTemplate },
+            { id: string }
+          >
+        ) => {
+          const template = response.data
+            ?.preferenceTemplate as IPreferenceTemplate;
+          setPreferenceTemplate(template);
+        }
+      );
+  }, [templateId]);
+
+  const handleUpdates = async (preferenceGrouping: IPreferenceTemplate) => {
+    // Update local state
+    setPreferenceTemplate(preferenceGrouping);
+    // Perform mutation to persist updates
+  };
+
+  return [preferenceTemplate, handleUpdates];
+};

--- a/packages/react-preferences/src/index.ts
+++ b/packages/react-preferences/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./components";

--- a/packages/react-preferences/tsconfig.json
+++ b/packages/react-preferences/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noImplicitAny": false,
+    "paths": {
+      "~/*": ["src/*"]
+    }
+  },
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+    "**/*.story.ts",
+    "**/dist/**",
+    "**/__tests__/**"
+  ],
+  "include": ["../types/@types/*/index.d.ts", "**/*.ts", "src/index.tsx"]
+}

--- a/packages/storybook/stories/react-preferences/with-preference-widget.stories.tsx
+++ b/packages/storybook/stories/react-preferences/with-preference-widget.stories.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Preferences } from "@trycourier/react-preferences";
+import { CourierProvider } from "@trycourier/react-provider";
+
+export default {
+  title: "Preferences",
+  component: Preferences,
+  argTypes: {
+    preferenceTemplateId: "string",
+  },
+  args: {},
+};
+
+export function Widget(): React.ReactElement {
+  const preferenceTemplateId = "D0N6ZNH5NFMA08JEXW6J6T3ZC6QA";
+  const { API_URL, CLIENT_KEY, USER_ID } = process.env;
+  return (
+    <div style={{ width: "25%" }}>
+      <CourierProvider apiUrl={API_URL} clientKey={CLIENT_KEY} userId={USER_ID}>
+        <Preferences preferenceTemplateId={preferenceTemplateId}></Preferences>
+      </CourierProvider>
+    </div>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14507,6 +14507,13 @@ react-toastify@^6.2.0:
     prop-types "^15.7.2"
     react-transition-group "^4.4.1"
 
+react-toggle@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.1.2.tgz#b00500832f925ad524356d909821821ae39f6c52"
+  integrity sha512-4Ohw31TuYQdhWfA6qlKafeXx3IOH7t4ZHhmRdwsm1fQREwOBGxJT+I22sgHqR/w8JRdk+AeMCJXPImEFSrNXow==
+  dependencies:
+    classnames "^2.2.5"
+
 react-transition-group@^4.3.0, react-transition-group@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"


### PR DESCRIPTION
## Description
```typescript
export function ConsumerComponent(): React.ReactElement {
  const preferenceTemplateId = "YOUR_TEMPLATE_ID";
  const { CLIENT_KEY, USER_ID } = {CLIENT_KEY:"YOUR_CLIENT_KEY", USER_ID: "YOUR_RECIPIENT_ID"};
  return (
    <CourierProvider clientKey={CLIENT_KEY} userId={USER_ID}>
      <Preferences preferenceTemplateId={preferenceTemplateId}></Preferences>
    </CourierProvider>
  );
}
```


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

