### PR TITLE
inapp updates

### DIFF
--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -6,7 +6,7 @@
     <style>
       body {
         cursor: default;
-        font-family: "Nunito", sans-serif;
+        font-family: "Nunito Sans", sans-serif;
         margin: 0;
         padding: 32px;
       }

--- a/packages/react-inbox/src/components/Actions/styled.ts
+++ b/packages/react-inbox/src/components/Actions/styled.ts
@@ -30,9 +30,7 @@ export const Action = styled.a<{ href: string; target: string }>(({ theme }) =>
       },
 
       "&:hover": {
-        color: theme?.brand?.inapp?.colors?.invertButtons
-          ? theme?.brand?.colors?.primary ?? "#9121C2"
-          : "#73819B",
+        color: "#73819B",
         background: "rgb(0 0 0 / 10%)",
       },
 

--- a/packages/react-inbox/src/components/Actions/styled.ts
+++ b/packages/react-inbox/src/components/Actions/styled.ts
@@ -32,7 +32,7 @@ export const Action = styled.a<{ href: string; target: string }>(({ theme }) =>
       "&:hover": {
         color: theme?.brand?.inapp?.colors?.invertButtons
           ? theme?.brand?.colors?.primary ?? "#9121C2"
-          : "white",
+          : "#73819B",
         background: "rgb(0 0 0 / 10%)",
       },
 

--- a/packages/react-inbox/src/components/Inbox/TippyStyle.ts
+++ b/packages/react-inbox/src/components/Inbox/TippyStyle.ts
@@ -1,6 +1,6 @@
-import styled from "styled-components";
+import { createGlobalStyle } from "styled-components";
 
-const TippyStyle = styled.div`
+const TippyStyle = createGlobalStyle`
   @keyframes badge-pulse {
     0% {
       -moz-box-shadow: 0 0 0 0 rgba(222, 80, 99, 0.3);
@@ -30,58 +30,12 @@ const TippyStyle = styled.div`
     outline: 0;
     transition-property: transform, visibility, opacity;
   }
-  .tippy-box[data-placement^="top"] > .tippy-arrow {
-    bottom: 0;
-  }
-  .tippy-box[data-placement^="top"] > .tippy-arrow:before {
-    bottom: -7px;
-    left: 0;
-    border-width: 8px 8px 0;
-    border-top-color: initial;
-    transform-origin: center top;
-  }
-  .tippy-box[data-placement^="bottom"] > .tippy-arrow {
-    top: 0;
-  }
-  .tippy-box[data-placement^="bottom"] > .tippy-arrow:before {
-    top: -7px;
-    left: 0;
-    border-width: 0 8px 8px;
-    border-bottom-color: initial;
-    transform-origin: center bottom;
-  }
-  .tippy-box[data-placement^="left"] > .tippy-arrow {
-    right: 0;
-  }
-  .tippy-box[data-placement^="left"] > .tippy-arrow:before {
-    border-width: 8px 0 8px 8px;
-    border-left-color: initial;
-    right: -7px;
-    transform-origin: center left;
-  }
-  .tippy-box[data-placement^="right"] > .tippy-arrow {
-    left: 0;
-  }
-  .tippy-box[data-placement^="right"] > .tippy-arrow:before {
-    left: -7px;
-    border-width: 8px 8px 8px 0;
-    border-right-color: initial;
-    transform-origin: center right;
-  }
+  
+  
   .tippy-box[data-inertia][data-state="visible"] {
     transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
   }
-  .tippy-arrow {
-    width: 16px;
-    height: 16px;
-    color: #333;
-  }
-  .tippy-arrow:before {
-    content: "";
-    position: absolute;
-    border-color: transparent;
-    border-style: solid;
-  }
+  
   .tippy-content {
     position: relative;
     padding: 5px 9px;

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -28,18 +28,19 @@ const UnreadIndicator = styled.div(({ theme }) =>
 
 const StyledTippy = styled(LazyTippy)<{
   placement?: TippyProps["placement"];
-}>(({ theme, placement }) =>
-  deepExtend(
+}>(({ theme, placement }) => {
+  return deepExtend(
     {
-      fontFamily: `"Nunito", sans-serif`,
+      fontFamily: `'Nunito Sans', sans-serif`,
       background: "#FFFFFF !important",
       backgroundColor: "#FFFFFF !important",
       boxShadow: "0px 12px 32px rgba(86, 43, 85, 0.3)",
       minWidth: 483,
       maxHeight: 545,
+
       borderRadius: theme?.brand?.inapp?.borderRadius ?? "24px",
-      overflow: "hidden",
       outline: "none",
+      overflow: "hidden",
       margin: ["left", "right"].includes(String(placement))
         ? "24px 0"
         : "0 24px",
@@ -54,16 +55,10 @@ const StyledTippy = styled(LazyTippy)<{
           maxHeight: 545,
         },
       },
-
-      ".tippy-arrow": {
-        color: theme?.brand?.inapp?.invertHeader
-          ? theme?.brand?.colors?.primary
-          : "#f9fafb",
-      },
     },
     theme.root
-  )
-);
+  );
+});
 
 const Inbox: React.FunctionComponent<InboxProps> = (props) => {
   const ref = useRef(null);
@@ -171,40 +166,45 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
   }
 
   return (
-    <ThemeProvider
-      theme={{
-        ...props.theme,
-        brand,
-      }}
-    >
+    <>
       <TippyStyle />
-      <StyledTippy {...tippyProps} content={<Messages ref={ref} {...props} />}>
-        <Bell
-          isOpen={isOpen}
-          aria-pressed="false"
-          className={`inbox-bell ${props.className ?? ""}`}
-          onClick={handleIconOnClick}
-          onMouseEnter={handleBellOnMouseEnter}
-          role="button"
-          tabIndex={0}
+      <ThemeProvider
+        theme={{
+          ...props.theme,
+          brand,
+        }}
+      >
+        <StyledTippy
+          {...tippyProps}
+          content={<Messages ref={ref} {...props} />}
         >
-          {props.renderIcon ? (
-            <span>
-              {props.renderIcon({
-                unreadMessageCount,
-              })}
-            </span>
-          ) : brand?.inapp?.icons?.bell ? (
-            <img src={brand?.inapp?.icons?.bell} />
-          ) : (
-            <BellSvg />
-          )}
-          {unreadMessageCount > 0 && (
-            <UnreadIndicator data-testid="unread-badge" />
-          )}
-        </Bell>
-      </StyledTippy>
-    </ThemeProvider>
+          <Bell
+            isOpen={isOpen}
+            aria-pressed="false"
+            className={`inbox-bell ${props.className ?? ""}`}
+            onClick={handleIconOnClick}
+            onMouseEnter={handleBellOnMouseEnter}
+            role="button"
+            tabIndex={0}
+          >
+            {props.renderIcon ? (
+              <span>
+                {props.renderIcon({
+                  unreadMessageCount,
+                })}
+              </span>
+            ) : brand?.inapp?.icons?.bell ? (
+              <img src={brand?.inapp?.icons?.bell} />
+            ) : (
+              <BellSvg />
+            )}
+            {unreadMessageCount > 0 && (
+              <UnreadIndicator data-testid="unread-badge" />
+            )}
+          </Bell>
+        </StyledTippy>
+      </ThemeProvider>
+    </>
   );
 };
 

--- a/packages/react-inbox/src/components/Message/index.tsx
+++ b/packages/react-inbox/src/components/Message/index.tsx
@@ -44,10 +44,10 @@ const Message: React.FunctionComponent<IMessageProps> = ({
       3. from props.brand.inapp.icons.message
       4. from remote brand.inapp.icons.message
     */
-    icon ||
-      brand?.inapp?.icons?.message ||
-      defaultIcon ||
-      !brand?.inapp?.disableMessageIcon
+
+    brand?.inapp?.disableMessageIcon
+      ? false
+      : icon || brand?.inapp?.icons?.message || defaultIcon
   );
   const timeAgo = getTimeAgo(created);
   const showMarkAsRead = !read && readTrackingId;

--- a/packages/react-inbox/src/components/Message/index.tsx
+++ b/packages/react-inbox/src/components/Message/index.tsx
@@ -47,7 +47,7 @@ const Message: React.FunctionComponent<IMessageProps> = ({
 
     brand?.inapp?.disableMessageIcon
       ? false
-      : icon || brand?.inapp?.icons?.message || defaultIcon
+      : (icon || defaultIcon) ?? brand?.inapp?.icons?.message
   );
   const timeAgo = getTimeAgo(created);
   const showMarkAsRead = !read && readTrackingId;

--- a/packages/react-inbox/src/components/Message/styled.tsx
+++ b/packages/react-inbox/src/components/Message/styled.tsx
@@ -125,7 +125,7 @@ export const getIcon = (icon?: false | string) => {
       return;
     }
 
-    if (typeof icon === "string") {
+    if (icon && typeof icon === "string") {
       return <Icon src={icon} />;
     }
 

--- a/packages/react-inbox/src/components/Message/styled.tsx
+++ b/packages/react-inbox/src/components/Message/styled.tsx
@@ -55,7 +55,7 @@ export const Title = styled.div(({ theme }) =>
 export const Body = styled.div(({ theme }) =>
   deepExtend(
     {
-      color: "#666666",
+      color: "#73819B",
       marginTop: "1px",
       wordBreak: "break-word",
       fontSize: "12px",

--- a/packages/react-inbox/src/components/OptionsDropdown/index.tsx
+++ b/packages/react-inbox/src/components/OptionsDropdown/index.tsx
@@ -11,7 +11,6 @@ const StyledTippy = styled(Tippy)`
     color: #344563 !important;
   }
   .tippy-content {
-    font-family: "Nunito", sans-serif;
     background-color: #344563;
     width: 108px;
     box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.1);

--- a/packages/react-inbox/src/reducer.ts
+++ b/packages/react-inbox/src/reducer.ts
@@ -151,7 +151,7 @@ export default (state: InboxState = initialState, action) => {
             title: action.payload.title,
             body: action.payload.body,
             data: action.payload.data,
-            trackingIds: action.payload.data.trackingIds,
+            trackingIds: action.payload.data?.trackingIds,
           },
           ...(state.messages || []),
         ],

--- a/packages/react-inbox/src/style.css
+++ b/packages/react-inbox/src/style.css
@@ -1,4 +1,0 @@
-@import url("https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600;700&display=swap");
-* {
-  font-family: Nunito;
-}

--- a/packages/react-provider/src/transports/types.ts
+++ b/packages/react-provider/src/transports/types.ts
@@ -1,7 +1,7 @@
 export interface ICourierMessage {
-  body?: string;
+  body?: string | React.ReactElement;
   icon?: string | false;
-  title?: string;
+  title?: string | React.ReactElement;
   data?: {
     clickAction?: string;
     clickTrackingId?: string;

--- a/packages/react-provider/src/ws.ts
+++ b/packages/react-provider/src/ws.ts
@@ -17,14 +17,16 @@ export class WS {
     const url = `${this.url}/?clientKey=${clientKey}`;
     this.connection = new WebSocket(url);
     if (!this.connection) {
-      console.log("error creating websocket connection");
+      console.error("error creating websocket connection");
       return;
     }
     this.connection.onopen = () => {
       this.connected = true;
     };
     this.connection.onclose = () => {
-      console.log("WS connection closed");
+      // i want to watch and see if we get connection closed events
+      // i think we will want to reconnect when this happens
+      console.warn("ws connection closed");
     };
     this.connection.onmessage = this.onMessage.bind(this);
   }

--- a/packages/react-provider/src/ws.ts
+++ b/packages/react-provider/src/ws.ts
@@ -16,8 +16,15 @@ export class WS {
   connect(clientKey: string): void {
     const url = `${this.url}/?clientKey=${clientKey}`;
     this.connection = new WebSocket(url);
+    if (!this.connection) {
+      console.log("error creating websocket connection");
+      return;
+    }
     this.connection.onopen = () => {
       this.connected = true;
+    };
+    this.connection.onclose = () => {
+      console.log("WS connection closed");
     };
     this.connection.onmessage = this.onMessage.bind(this);
   }

--- a/packages/react-toast/src/components/Actions/styled.ts
+++ b/packages/react-toast/src/components/Actions/styled.ts
@@ -27,32 +27,27 @@ export const Container = styled.div(({ theme }) =>
   )
 );
 
-const getButtonStyles = (theme, styles) =>
+const getButtonStyles = (theme) =>
   deepExtend(
     {
       flex: "1",
       display: "flex",
       justifyContent: "center",
       alignItems: "center",
-      color: theme?.brand?.inapp?.colors?.invertButtons
-        ? "white"
-        : theme?.brand?.colors?.primary ?? "#9121C2",
-      backgroundColor: theme?.brand?.inapp?.colors?.invertButtons
-        ? theme?.brand?.colors?.primary
-        : "white",
+      color: "#73819B",
+      backgroundColor: "white",
       textDecoration: "none",
       "&:hover": {
-        color: theme?.brand?.colors?.primary ?? "#9121C2",
         background: "rgb(0 0 0 / 10%)",
       },
     },
-    styles
+    theme
   );
 
 export const Details = styled.a(({ theme }) =>
-  getButtonStyles(theme, theme?.message?.actions?.details)
+  getButtonStyles(theme?.message?.actions?.details)
 );
 
 export const Dismiss = styled.a(({ theme }) =>
-  getButtonStyles(theme, theme?.message?.actions?.dismiss)
+  getButtonStyles(theme?.message?.actions?.dismiss)
 );

--- a/packages/react-toast/src/components/Body/helpers.tsx
+++ b/packages/react-toast/src/components/Body/helpers.tsx
@@ -8,7 +8,7 @@ export function getIcon(icon) {
     return;
   }
 
-  if (typeof icon === "string") {
+  if (icon && typeof icon === "string") {
     // eslint-disable-next-line react/display-name
     return (props) => <Icon src={icon} {...props} />;
   }

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -43,7 +43,9 @@ const ToastBody: React.FunctionComponent<Partial<ICourierToastMessage>> = ({
       3. from props.brand.inapp.icons.message
       4. from remote brand.inapp.icons.message
     */
-    icon || config?.defaultIcon || brand?.inapp?.icons?.message
+    brand?.inapp?.disableMessageIcon
+      ? false
+      : icon || config?.defaultIcon || brand?.inapp?.icons?.message
   );
 
   return (

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -45,7 +45,7 @@ const ToastBody: React.FunctionComponent<Partial<ICourierToastMessage>> = ({
     */
     brand?.inapp?.disableMessageIcon
       ? false
-      : icon || config?.defaultIcon || brand?.inapp?.icons?.message
+      : (icon || config?.defaultIcon) ?? brand?.inapp?.icons?.message
   );
 
   return (

--- a/packages/react-toast/src/components/Body/styled.ts
+++ b/packages/react-toast/src/components/Body/styled.ts
@@ -28,10 +28,9 @@ export const Message = styled.div(({ theme }) =>
     {
       flexShrink: 0,
       padding: 12,
-      fontFamily: "Nunito Sans, sans-serif",
       fontSize: "12px",
       fontStyle: "normal",
-      fontWeight: "400",
+      fontWeight: "normal",
       lineHeight: "14px",
       maxWidth: "165px",
       letterSpacing: "0em",
@@ -41,6 +40,7 @@ export const Message = styled.div(({ theme }) =>
       overflow: "hidden",
       overflowWrap: "break-word",
       alignSelf: "center",
+      color: "#73819B",
     },
     theme?.message?.contents
   )

--- a/packages/react-toast/src/components/Body/styled.ts
+++ b/packages/react-toast/src/components/Body/styled.ts
@@ -5,7 +5,6 @@ export const iconStyles = ({ theme }) =>
   deepExtend(
     {
       flexShrink: "0",
-      marginLeft: 12,
       objectFit: "contain",
       alignSelf: "center",
       padding: "2px",
@@ -21,6 +20,7 @@ export const iconStyles = ({ theme }) =>
 export const Icon = styled.img(iconStyles);
 export const Container = styled.div`
   display: flex;
+  padding: 0 12px;
 `;
 
 export const Message = styled.div(({ theme }) =>

--- a/packages/react-toast/src/components/Toast/index.tsx
+++ b/packages/react-toast/src/components/Toast/index.tsx
@@ -22,6 +22,7 @@ export const Toast: React.FunctionComponent<
 > = (props) => {
   const courierContext = useCourier();
 
+  console.log("props", props);
   if (props.config) {
     console.warn(
       "Config as a props is DEPRECATED and WILL be removed in a future version"

--- a/packages/react-toast/src/components/Toast/styled.ts
+++ b/packages/react-toast/src/components/Toast/styled.ts
@@ -3,8 +3,8 @@ import { ToastContainer } from "react-toastify";
 
 export const toastStyles = ({ theme }) => ({
   ["&.Toastify__toast-container"]: {
-    fontFamily: `"Nunito", sans-serif`,
     "&, *": {
+      fontFamily: `'Nunito Sans', sans-serif`,
       boxSizing: "border-box",
     },
     ...theme?.root,
@@ -23,7 +23,7 @@ export const toastStyles = ({ theme }) => ({
     ...theme?.body,
   },
   [".Toastify__progress-bar"]: {
-    background: theme?.brand?.colors?.secondary ?? "#9121C2",
+    background: theme?.brand?.colors?.primary ?? "#9121C2",
     height: 3,
     top: 0,
     ...theme?.progressBar,

--- a/packages/react-toast/src/index.tsx
+++ b/packages/react-toast/src/index.tsx
@@ -19,7 +19,7 @@ export const ToastProvider: React.FunctionComponent<
   return (
     <ThemeProvider theme={config.theme ?? {}}>
       <CourierProvider clientKey={clientKey} transport={transport}>
-        <Toast config={config} />
+        <Toast {...config} />
         {children}
       </CourierProvider>
     </ThemeProvider>

--- a/packages/storybook/stories/inbox/examples.stories.tsx
+++ b/packages/storybook/stories/inbox/examples.stories.tsx
@@ -135,22 +135,6 @@ export function Branded() {
   );
 }
 
-export function CustomMiddleware() {
-  return (
-    <CourierProvider
-      apiUrl={API_URL}
-      clientKey={CLIENT_KEY}
-      userId={USER_ID}
-      transport={courierTransport}
-      middleware={[middleware]}
-    >
-      <Toast />
-      <Inbox />
-      <UseInbox />
-    </CourierProvider>
-  );
-}
-
 export function MultipleInbox() {
   return (
     <CourierProvider

--- a/packages/storybook/stories/inbox/with-toast.stories.tsx
+++ b/packages/storybook/stories/inbox/with-toast.stories.tsx
@@ -26,10 +26,10 @@ if (typeof window !== "undefined") {
 
 export function Default() {
   useEffect(() => {
-    courierTransport?.subscribe(USER_ID, channel);
+    courierTransport?.subscribe(USER_ID);
 
     return () => {
-      courierTransport?.unsubscribe(USER_ID, channel);
+      courierTransport?.unsubscribe(USER_ID);
     };
   }, []);
 
@@ -51,21 +51,17 @@ export function Default() {
     <CourierProvider
       apiUrl={API_URL}
       clientKey={clientKey}
-      wsUrl={process.env.WS_URL}
+      transport={courierTransport}
       userId={USER_ID}
+      brand={{
+        inapp: {
+          disableMessageIcon: true,
+        },
+      }}
     >
-      <div style={{ display: "flex" }}>
-        <Toast />
-        <Inbox
-          title="Inbox"
-          brand={{
-            inapp: {
-              disableMessageIcon: true,
-            },
-          }}
-        />
-        <button onClick={handleNotify}>Test</button>
-      </div>
+      <Toast />
+      <Inbox />
+      <button onClick={handleNotify}>Test</button>
     </CourierProvider>
   );
 }

--- a/packages/storybook/stories/toast/examples.stories.tsx
+++ b/packages/storybook/stories/toast/examples.stories.tsx
@@ -42,9 +42,39 @@ export function Default({ bodyText }) {
   );
 }
 
+export function CustomTitleAndBody() {
+  const handleOnClick = () => {
+    console.log("click");
+  };
+  return (
+    <CourierProvider>
+      <ToastBody
+        onClick={handleOnClick}
+        body={<h3>Hello World</h3>}
+        title={<h1>Title</h1>}
+        brand={{
+          inapp: {
+            colors: {
+              invertButtons: true,
+            },
+            icons: {
+              message:
+                "https://d33wubrfki0l68.cloudfront.net/ca2747f11cc64d0e424e27b4a804b9d981b22453/9ab46/_next/static/images/logo@2x-5d5af82635bfdd3ad24e54f9eb364097.png",
+            },
+          },
+          colors: {
+            primary: "red",
+            secondary: "green",
+          },
+        }}
+      />
+    </CourierProvider>
+  );
+}
+
 export function TruncatedMessage() {
   return (
-    <CourierProvider clientKey="client-key" userId="user-id">
+    <CourierProvider>
       <ToastBody
         body="This is a really long message lalalalalala"
         title="This is a really long title lalalalalala"
@@ -60,7 +90,7 @@ export function WithCourierProvider({ bodyText }) {
   }
 
   return (
-    <CourierProvider clientKey="client-key" userId="user-id">
+    <CourierProvider>
       <Toast
         brand={{
           inapp: {
@@ -146,7 +176,7 @@ export function WithClickAction({ bodyText }) {
   }
 
   return (
-    <ToastProvider clientKey="client-key">
+    <ToastProvider>
       <DefaultComponent body={bodyText} />
     </ToastProvider>
   );


### PR DESCRIPTION
## Description

- Disabling message icon doesn't hide the icon in inbox or toast

- Simplify the branding of the toast message to avoid ugly inverted button state. In v1, let's just have the both buttons be rgb(52, 69, 99) to match the toast title font color

- Change Inbox design font from Nunito to Nunito Sans.

- Make the toast top bar link to the primary color

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
