### PR TITLE
better loading

### DIFF
--- a/packages/react-inbox/src/components/Messages/loading.tsx
+++ b/packages/react-inbox/src/components/Messages/loading.tsx
@@ -12,7 +12,7 @@ const MessageSkeleton: React.FunctionComponent = () => {
         style={{ marginRight: 12 }}
       />
       <Contents style={{ width: "100%" }}>
-        <Skeleton count={2} />
+        <Skeleton count={3} />
       </Contents>
       <div style={{ width: "100px", marginLeft: 12, marginTop: -6 }}>
         <Skeleton count={1} height={20} />


### PR DESCRIPTION
## Description

right now the loading placeholder is smaller than a message which makes the inbox size jump between tabs.  this fixes that.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
