### PR TITLE
inapp updates for inbox/toast

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -124,7 +124,11 @@ To listen for actions that happen inside Courier's SDK.
 
 ## [Configuring Components](#config)
 
-You can configure components in 2 different ways. Inline html attributes but also through `window.courierConfig`.
+You can configure components in 2 different ways. Inline html attributes but also through `window.courierConfig`. These are the same properties passed to the React components
+
+[Inbox Config](https://github.com/trycourier/courier-react/blob/main/packages/react-inbox/docs/0.props.md)
+
+[Toast Config](https://github.com/trycourier/courier-react/blob/main/packages/react-toast/docs/3.props.md)
 
 > Inline configuration attributes will take precedence over `window.courierConfig` options
 
@@ -153,3 +157,11 @@ window.courierConfig = {
   },
 };
 ```
+
+## [Updating Component Configs](#updating-config)
+
+You update configuration of components by using:
+
+`window.courier.inbox.setConfig(config: InboxConfig);`
+
+`window.courier.toast.setConfig(config: ToastConfig);`

--- a/packages/components/src/components/index.tsx
+++ b/packages/components/src/components/index.tsx
@@ -2,6 +2,7 @@ import { getAttrsAsJson } from "../lib/get-attrs-as-json";
 import React, { useState, useEffect, Suspense, lazy } from "react";
 import { createPortal } from "react-dom";
 import { CourierSdk } from "./CourierSdk";
+import { useCourier } from "@trycourier/react-provider";
 
 const Toast = lazy(() => import("./Toast"));
 const Inbox = lazy(() => import("./Inbox"));
@@ -12,6 +13,24 @@ const querySelector = (element: HTMLElement, selector: string) => {
   }
 
   return element.querySelector(selector);
+};
+
+export const SetCourierConfig: React.FunctionComponent = () => {
+  const courier = useCourier();
+
+  useEffect(() => {
+    window.courier.inbox = {
+      ...window.courier.inbox,
+      setConfig: courier.initInbox,
+    };
+
+    window.courier.toast = {
+      ...window.courier.toast,
+      setConfig: courier.initToast,
+    };
+  }, []);
+
+  return null;
 };
 
 export const CourierComponents: React.FunctionComponent = () => {

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -60,6 +60,7 @@
   </head>
   <body>
     <h1>Treva Homepage</h1>
+    <courier-inbox></courier-inbox>
     <courier-toast></courier-toast>
     <div id="root" />
   </body>

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render } from "react-dom";
 
 import { CourierProvider } from "@trycourier/react-provider";
-import { CourierComponents } from "./components";
+import { CourierComponents, SetCourierConfig } from "./components";
 
 declare global {
   interface Window {
@@ -11,10 +11,12 @@ declare global {
         [action: string]: Array<() => void>;
       };
       toast?: {
-        add: (message: { title: string; body: string }) => void;
+        setConfig?: (config: any) => void;
+        add?: (message: { title: string; body: string }) => void;
       };
       inbox?: {
-        config: any;
+        setConfig?: (config: any) => void;
+        config?: any;
       };
       transport?: any;
       init: (config: ICourierConfig) => void;
@@ -62,6 +64,7 @@ const initCourier = async (courierConfig?: ICourierConfig) => {
       userSignature={userSignature}
       wsUrl={wsUrl}
     >
+      <SetCourierConfig />
       <CourierComponents />
     </CourierProvider>,
     courierRoot

--- a/packages/react-inbox/docs/0.props.md
+++ b/packages/react-inbox/docs/0.props.md
@@ -1,7 +1,15 @@
 ### [Props](#props)
 
 ```
-interface InboxProps = {
+interface ITab {
+  filters: {
+    isRead?: boolean;
+  };
+  label: string;
+  id: string;
+}
+
+interface InboxProps {
   //Brand Override
   brand?: Brand;
 
@@ -34,5 +42,12 @@ interface InboxProps = {
   // Inbox Title Override
   title?: string;
   trigger?: "click" | "hover";
+
+  labels?: {
+    backToInbox?: string;
+    markAsRead?: string;
+    markAllAsRead?: string;
+    markAsUnread?: string;
+  }
 }
 ```

--- a/packages/react-inbox/src/components/Message/helpers.ts
+++ b/packages/react-inbox/src/components/Message/helpers.ts
@@ -1,3 +1,4 @@
+import { useCourier } from "@trycourier/react-provider";
 import distanceInWords from "date-fns/formatDistanceStrict";
 import { MESSAGE_LABELS } from "~/constants";
 
@@ -29,7 +30,7 @@ export const getAction = ({ clickAction, trackingIds, trackEvent }) => {
   };
 };
 
-export const getOptions = ({
+export const useMessageOptions = ({
   showMarkAsRead,
   showMarkAsUnread,
   markMessageRead,
@@ -38,16 +39,17 @@ export const getOptions = ({
   readTrackingId,
   unreadTrackingId,
 }) => {
+  const { inbox } = useCourier();
   return [
     showMarkAsRead && {
-      label: MESSAGE_LABELS.MARK_AS_READ,
+      label: inbox?.labels?.markAsRead ?? MESSAGE_LABELS.MARK_AS_READ,
       onClick: () => {
         markMessageRead(messageId, readTrackingId || "");
       },
     },
 
     showMarkAsUnread && {
-      label: MESSAGE_LABELS.MARK_AS_UNREAD,
+      label: inbox?.labels?.markAsUnread ?? MESSAGE_LABELS.MARK_AS_UNREAD,
       onClick: () => {
         markMessageUnread(messageId, unreadTrackingId || "");
       },

--- a/packages/react-inbox/src/components/Message/index.tsx
+++ b/packages/react-inbox/src/components/Message/index.tsx
@@ -13,7 +13,7 @@ import {
 } from "./styled";
 import useInbox from "~/hooks/use-inbox";
 import { IMessageProps } from "./types";
-import { getAction, getOptions, getTimeAgo } from "./helpers";
+import { getAction, useMessageOptions, getTimeAgo } from "./helpers";
 import { useCourier } from "@trycourier/react-provider";
 
 const Message: React.FunctionComponent<IMessageProps> = ({
@@ -53,7 +53,7 @@ const Message: React.FunctionComponent<IMessageProps> = ({
     trackEvent: createTrackEvent,
   });
 
-  const options = getOptions({
+  const messageOptions = useMessageOptions({
     showMarkAsRead,
     showMarkAsUnread,
     markMessageRead,
@@ -86,9 +86,11 @@ const Message: React.FunctionComponent<IMessageProps> = ({
 
             if (block.type === "action") {
               return (
-                <ActionBlock key={index} href={block.url} target="_blank">
-                  {block.text}
-                </ActionBlock>
+                <div>
+                  <ActionBlock key={index} href={block.url} target="_blank">
+                    {block.text}
+                  </ActionBlock>
+                </div>
               );
             }
           })
@@ -104,7 +106,9 @@ const Message: React.FunctionComponent<IMessageProps> = ({
         )}
       </Contents>
       <TimeAgo>{timeAgo}</TimeAgo>
-      {options?.length ? <OptionsDropdown options={options} /> : undefined}
+      {messageOptions?.length ? (
+        <OptionsDropdown options={messageOptions} />
+      ) : undefined}
     </Container>
   );
 };

--- a/packages/react-inbox/src/components/Messages/Header/index.tsx
+++ b/packages/react-inbox/src/components/Messages/Header/index.tsx
@@ -31,7 +31,7 @@ const Header: React.FunctionComponent<IHeaderProps> = ({
   markAllAsRead,
   messages = [],
 }) => {
-  const { brand } = useCourier();
+  const { inbox, brand } = useCourier();
   const { view, setView } = useInbox();
   const handleSetView = (newView) => (event: React.MouseEvent) => {
     event.preventDefault();
@@ -51,7 +51,7 @@ const Header: React.FunctionComponent<IHeaderProps> = ({
       <div className="actions">
         {currentTab?.filters?.isRead === false && messages.length > 0 && (
           <MarkAllAsRead onClick={markAllAsRead} style={{ cursor: "pointer" }}>
-            Mark all as read
+            {inbox?.labels?.markAllAsRead ?? "Mark all as read"}
           </MarkAllAsRead>
         )}
         {brand?.preferenceTemplates?.length > 0 && (
@@ -66,7 +66,7 @@ const Header: React.FunctionComponent<IHeaderProps> = ({
       <Heading flexDirection="column">
         Preferences
         <PreferenceSubHeader onClick={handleSetView("messages")}>
-          {`◀ Back to Inbox`}
+          {`◀ ${inbox?.labels?.backToInbox ?? "Back to Inbox"}`}
         </PreferenceSubHeader>
       </Heading>
       <SettingsIconButton onClick={handleSetView("messages")}>

--- a/packages/react-inbox/src/components/Messages/index.tsx
+++ b/packages/react-inbox/src/components/Messages/index.tsx
@@ -29,7 +29,6 @@ const Messages: React.ForwardRefExoticComponent<
 > = React.forwardRef(
   (
     {
-      title = "Inbox",
       renderContainer,
       renderHeader,
       renderMessage,
@@ -42,6 +41,7 @@ const Messages: React.ForwardRefExoticComponent<
     const { fetchRecipientPreferences } = usePreferencesActions();
 
     const {
+      title = "Inbox",
       brand,
       currentTab,
       fetchMessages,

--- a/packages/react-inbox/src/components/OptionsDropdown/Options.tsx
+++ b/packages/react-inbox/src/components/OptionsDropdown/Options.tsx
@@ -25,6 +25,7 @@ const Option = styled.button`
   background: transparent;
   border: none;
   outline: none;
+  border-radius: 4px;
 
   :hover {
     background-color: #5c6a82;

--- a/packages/react-inbox/src/components/OptionsDropdown/index.tsx
+++ b/packages/react-inbox/src/components/OptionsDropdown/index.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import styled from "styled-components";
 import Tippy, { TippyProps } from "@tippyjs/react";
 import OptionsIcon from "~/assets/options.svg";
 import { OptionsIconButton } from "./styled";
 import Options from "./Options";
+import { useClickOutside } from "~/hooks";
 
 const StyledTippy = styled(Tippy)`
   transform: translateX(-1px);
@@ -34,6 +35,8 @@ const tippyProps: TippyProps = {
 };
 
 function OptionsDropdown({ options }) {
+  const ref = useRef(null);
+
   const [showOptions, setShowOptions] = useState(false);
 
   const handleShowOptions = (event: React.MouseEvent) => {
@@ -41,11 +44,22 @@ function OptionsDropdown({ options }) {
     setShowOptions(!showOptions);
   };
 
+  const handleClickOutside: EventListener = (event) => {
+    event?.preventDefault();
+    setShowOptions(false);
+  };
+
+  useClickOutside(ref, handleClickOutside);
+
   return (
     <StyledTippy
       {...tippyProps}
       visible={showOptions}
-      content={<Options options={options} onClose={handleShowOptions} />}
+      content={
+        <span ref={ref}>
+          <Options options={options} onClose={handleShowOptions} />{" "}
+        </span>
+      }
     >
       <OptionsIconButton onClick={handleShowOptions}>
         <OptionsIcon />

--- a/packages/react-inbox/src/reducer.ts
+++ b/packages/react-inbox/src/reducer.ts
@@ -15,6 +15,13 @@ const makeMessage = (message): IMessage => ({
 
 export interface InboxState {
   brand?: Brand;
+  title?: string;
+  labels?: {
+    markAsRead?: string;
+    markAsUnread?: string;
+    markAllAsRead?: string;
+    backToInbox?: string;
+  };
   defaultIcon?: false | string;
   tabs?: Array<ITab>;
   isLoading?: boolean;

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -34,6 +34,12 @@ export interface InboxProps {
   tabs?: Array<ITab>;
   theme?: ThemeObject;
   title?: string;
+  labels?: {
+    markAsRead?: string;
+    markAsUnread?: string;
+    markAllAsRead?: string;
+    backToInbox?: string;
+  };
   trigger?: TippyProps["trigger"];
 }
 

--- a/packages/react-provider/src/hooks/use-courier-actions.ts
+++ b/packages/react-provider/src/hooks/use-courier-actions.ts
@@ -4,13 +4,13 @@ const useCourierActions = (dispatch) => {
   return {
     initToast: (payload) => {
       dispatch({
-        type: "INIT_TOAST",
+        type: "toast/INIT",
         payload,
       });
     },
     initInbox: (payload) => {
       dispatch({
-        type: "INIT_INBOX",
+        type: "inbox/INIT",
         payload,
       });
     },

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -72,14 +72,16 @@ const ToastBody: React.FunctionComponent<Partial<ICourierToastMessage>> = ({
 
             if (block.type === "action") {
               return (
-                <ActionBlock
-                  data-testid={`action-${index}`}
-                  href={block.url}
-                  key={index}
-                  target="_blank"
-                >
-                  {block.text}
-                </ActionBlock>
+                <div>
+                  <ActionBlock
+                    data-testid={`action-${index}`}
+                    href={block.url}
+                    key={index}
+                    target="_blank"
+                  >
+                    {block.text}
+                  </ActionBlock>
+                </div>
               );
             }
           })

--- a/packages/storybook/stories/inbox/index.stories.tsx
+++ b/packages/storybook/stories/inbox/index.stories.tsx
@@ -33,7 +33,7 @@ export const Theme = () => {
   return <ReactMarkdown>{themeMd}</ReactMarkdown>;
 };
 
-export const ThemeExammple = () => {
+export const ThemeExample = () => {
   const theme = {
     container: {
       background: "green",
@@ -181,6 +181,10 @@ const middleware = () => (next) => (action) => {
               created: "2021-04-06T18:02:28.065Z",
               read: false,
               content: {
+                trackingIds: {
+                  readTrackingId: 123,
+                  unreadTrackingId: 123,
+                },
                 title: "Unread Message",
                 body: "This Message is Unread",
               },
@@ -190,6 +194,10 @@ const middleware = () => (next) => (action) => {
               created: "2021-04-06T18:02:28.065Z",
               read: true,
               content: {
+                trackingIds: {
+                  readTrackingId: 123,
+                  unreadTrackingId: 123,
+                },
                 title: "Read Message",
                 body: "This Message is Read",
               },
@@ -227,6 +235,46 @@ export const Hooks = () => {
           userId={USER_ID}
         >
           <MyCustomInbox />
+        </CourierProvider>
+      </div>
+    </>
+  );
+};
+
+export const CustomLabels = () => {
+  return (
+    <>
+      <ReactMarkdown>{hooksMd}</ReactMarkdown>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "top",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <ReactMarkdown>{`## Example`}</ReactMarkdown>
+          <ReactMarkdown>{`\`\`\`javascript\n<Inbox labels={{
+            markAsRead: "markey read pwease",
+            markAsUnread: "jk, unread me",
+          }} />\n\`\`\``}</ReactMarkdown>
+        </div>
+        <CourierProvider
+          middleware={[middleware]}
+          wsUrl={WS_URL}
+          apiUrl={API_URL}
+          clientKey={CLIENT_KEY}
+          userId={USER_ID}
+        >
+          <Inbox
+            isOpen={true}
+            labels={{
+              markAsRead: "markey read pwease",
+              markAsUnread: "jk, unread me",
+              backToInbox: "back it up!",
+              markAllAsRead: "mark em all captn",
+            }}
+          />
         </CourierProvider>
       </div>
     </>

--- a/packages/storybook/stories/toast/examples.stories.tsx
+++ b/packages/storybook/stories/toast/examples.stories.tsx
@@ -88,6 +88,11 @@ export function WithBlocks() {
             text: "View Details",
             url: "https://www.courier.com",
           },
+          {
+            type: "action",
+            text: "View Details2",
+            url: "https://www.courier.com",
+          },
         ]}
         title="This is a really long title lalalalalala"
       />


### PR DESCRIPTION
## Description

- support labels in Inbox for `mark as read` `mark as unread` `mark all as read` `back to inbox`
- fix action buttons > 1 from being next to eachother on the same line
- support `window.courier.inbox.setConfig` to dynamically update config
- make click outside of "message options" close tooltip

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
