### PR TITLE
C-4972: Expose bell rendering via props

### DIFF
--- a/packages/react-inbox/README.md
+++ b/packages/react-inbox/README.md
@@ -81,7 +81,12 @@ interface InboxProps = {
   placement?: "top" | "left" | "right" | "bottom";
 
   // Render Props for Custom Rendering
-  renderBell?: React.FunctionComponent;
+  renderBell?: React.FunctionComponent<{
+    className?: string;
+    isOpen?: boolean;
+    onClick?: (event: React.MouseEvent) => void;
+    onMouseEnter?: (event: React.MouseEvent) => void;
+  }>;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/README.md
+++ b/packages/react-inbox/README.md
@@ -81,6 +81,7 @@ interface InboxProps = {
   placement?: "top" | "left" | "right" | "bottom";
 
   // Render Props for Custom Rendering
+  renderBell?: React.FunctionComponent;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/docs/0.props.md
+++ b/packages/react-inbox/docs/0.props.md
@@ -27,6 +27,7 @@ interface InboxProps {
     currentTab?: ITab;
     tabs?: ITab[];
   }>;
+  renderBell?: React.FunctionComponent;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/docs/0.props.md
+++ b/packages/react-inbox/docs/0.props.md
@@ -27,7 +27,12 @@ interface InboxProps {
     currentTab?: ITab;
     tabs?: ITab[];
   }>;
-  renderBell?: React.FunctionComponent;
+  renderBell?: React.FunctionComponent<{
+    className?: string;
+    isOpen?: boolean;
+    onClick?: (event: React.MouseEvent) => void;
+    onMouseEnter?: (event: React.MouseEvent) => void;
+  }>;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/docs/2.render-props.md
+++ b/packages/react-inbox/docs/2.render-props.md
@@ -9,6 +9,7 @@
     currentTab?: ITab;
     tabs?: ITab[];
   }>;
+  renderBell?: React.FunctionComponent;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/docs/2.render-props.md
+++ b/packages/react-inbox/docs/2.render-props.md
@@ -9,7 +9,12 @@
     currentTab?: ITab;
     tabs?: ITab[];
   }>;
-  renderBell?: React.FunctionComponent;
+  renderBell?: React.FunctionComponent<{
+    className?: string;
+    isOpen?: boolean;
+    onClick?: (event: React.MouseEvent) => void;
+    onMouseEnter?: (event: React.MouseEvent) => void;
+  }>;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -246,7 +246,14 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
   const isMobile = windowSize?.width ? windowSize?.width <= 480 : false;
 
   const BellWrapper = () => {
-    return props.renderBell ? props.renderBell({}) ?? bell : bell;
+    return props.renderBell
+      ? props.renderBell({
+          className: `inbox-bell ${props.className ?? ""}`,
+          isOpen: isOpen ?? false,
+          onClick: handleIconOnClick,
+          onMouseEnter: handleBellOnMouseEnter,
+        }) ?? bell
+      : bell;
   };
 
   return (

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -245,6 +245,10 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
 
   const isMobile = windowSize?.width ? windowSize?.width <= 480 : false;
 
+  const BellWrapper = () => {
+    return props.renderBell ? props.renderBell({}) ?? bell : bell;
+  };
+
   return (
     <>
       <TippyGlobalStyle />
@@ -263,12 +267,12 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
                 {...tippyProps}
                 content={<Messages ref={ref} {...props} />}
               >
-                {bell}
+                {BellWrapper()}
               </StyledTippy>
             )}
           </>
         ) : (
-          bell
+          BellWrapper()
         )}
       </ThemeProvider>
     </>

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -21,7 +21,12 @@ export interface InboxProps {
     currentTab?: ITab;
     tabs?: ITab[];
   }>;
-  renderBell?: React.FunctionComponent;
+  renderBell?: React.FunctionComponent<{
+    className?: string;
+    isOpen?: boolean;
+    onClick?: (event: React.MouseEvent) => void;
+    onMouseEnter?: (event: React.MouseEvent) => void;
+  }>;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -21,6 +21,7 @@ export interface InboxProps {
     currentTab?: ITab;
     tabs?: ITab[];
   }>;
+  renderBell?: React.FunctionComponent;
   renderFooter?: React.FunctionComponent;
   renderHeader?: React.FunctionComponent;
   renderIcon?: React.FunctionComponent<{

--- a/packages/storybook/stories/inbox/custom-components.tsx
+++ b/packages/storybook/stories/inbox/custom-components.tsx
@@ -23,3 +23,7 @@ export const CustomTabs: React.FunctionComponent = () => {
 export const CustomNoMessages: React.FunctionComponent = () => {
   return <div>No Messages</div>;
 };
+
+export const CustomBell: React.FunctionComponent = () => {
+  return <div>Bell</div>;
+};

--- a/packages/storybook/stories/inbox/index.stories.tsx
+++ b/packages/storybook/stories/inbox/index.stories.tsx
@@ -10,6 +10,7 @@ import { Inbox } from "@trycourier/react-inbox";
 
 import customComponentsString from "!raw-loader!./custom-components.tsx";
 import {
+  CustomBell,
   CustomHeader,
   CustomContainer,
   CustomFooter,
@@ -109,6 +110,7 @@ export const RenderPropsExammple = () => {
   const props = {
     isOpen: true,
     title: "Custom Title",
+    renderBell: CustomBell,
     renderContainer: CustomContainer,
     renderHeader: CustomHeader,
     renderFooter: CustomFooter,


### PR DESCRIPTION
## Description

Expose bell via props

Storybook screenshot where bell was custom rendered:
<img width="391" alt="Screen Shot 2022-01-26 at 5 46 36 AM" src="https://user-images.githubusercontent.com/6154318/151174851-bb3012bb-f3e1-40bd-a4a6-b9f6fe08ee83.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
