### PR TITLE
[C-4945] fetches default brand in `in-app` 

### DIFF
--- a/packages/react-inbox/__mocks__/api/brand.ts
+++ b/packages/react-inbox/__mocks__/api/brand.ts
@@ -1,6 +1,6 @@
-export const DEFAULT_BRAND = {
+export const INAPP_BRAND = {
   data: {
-    defaultBrand: {
+    inAppBrand: {
       settings: {
         colors: {
           primary: "#FFFFFF",
@@ -23,15 +23,15 @@ export const DEFAULT_BRAND = {
       execution: {
         resolvers: [
           {
-            path: ["defaultBrand"],
+            path: ["inAppBrand"],
             parentType: "Query",
-            fieldName: "defaultBrand",
+            fieldName: "inAppBrand",
             returnType: "Brand",
             startOffset: 241418,
             duration: 107085289,
           },
           {
-            path: ["defaultBrand", "settings"],
+            path: ["inAppBrand", "settings"],
             parentType: "Brand",
             fieldName: "settings",
             returnType: "BrandSettings",
@@ -39,7 +39,7 @@ export const DEFAULT_BRAND = {
             duration: 35225,
           },
           {
-            path: ["defaultBrand", "settings", "colors"],
+            path: ["inAppBrand", "settings", "colors"],
             parentType: "BrandSettings",
             fieldName: "colors",
             returnType: "BrandColors",
@@ -47,7 +47,7 @@ export const DEFAULT_BRAND = {
             duration: 15525,
           },
           {
-            path: ["defaultBrand", "settings", "colors", "primary"],
+            path: ["inAppBrand", "settings", "colors", "primary"],
             parentType: "BrandColors",
             fieldName: "primary",
             returnType: "String",
@@ -55,7 +55,7 @@ export const DEFAULT_BRAND = {
             duration: 10134,
           },
           {
-            path: ["defaultBrand", "settings", "colors", "secondary"],
+            path: ["inAppBrand", "settings", "colors", "secondary"],
             parentType: "BrandColors",
             fieldName: "secondary",
             returnType: "String",
@@ -63,7 +63,7 @@ export const DEFAULT_BRAND = {
             duration: 7991,
           },
           {
-            path: ["defaultBrand", "settings", "colors", "tertiary"],
+            path: ["inAppBrand", "settings", "colors", "tertiary"],
             parentType: "BrandColors",
             fieldName: "tertiary",
             returnType: "String",
@@ -71,7 +71,7 @@ export const DEFAULT_BRAND = {
             duration: 7620,
           },
           {
-            path: ["defaultBrand", "settings", "inapp"],
+            path: ["inAppBrand", "settings", "inapp"],
             parentType: "BrandSettings",
             fieldName: "inapp",
             returnType: "BrandInApp",

--- a/packages/react-inbox/__tests__/closed/index.tsx
+++ b/packages/react-inbox/__tests__/closed/index.tsx
@@ -7,7 +7,7 @@ import fetchMock from "fetch-mock";
 import { Inbox } from "../../src";
 
 import * as fetchMessages from "../../src/actions/messages";
-import { DEFAULT_BRAND } from "../../__mocks__/api/brand";
+import { INAPP_BRAND } from "../../__mocks__/api/brand";
 
 describe("Test Bell Initial Render", () => {
   beforeEach(() => {
@@ -83,11 +83,11 @@ describe("Test Bell State", () => {
           operationName: "MessageCount",
         },
       })
-      .post("https://api.courier.com/client/q", DEFAULT_BRAND, {
+      .post("https://api.courier.com/client/q", INAPP_BRAND, {
         overwriteRoutes: false,
         matchPartialBody: true,
         body: {
-          operationName: "GetDefaultBrand",
+          operationName: "GetInAppBrand",
         },
       });
   });

--- a/packages/react-provider/src/actions/brand.ts
+++ b/packages/react-provider/src/actions/brand.ts
@@ -45,9 +45,9 @@ query GetBrand($brandId: String!) {
 }
 `;
 
-const GET_DEFAULT_BRAND = `
-query GetDefaultBrand {
-  defaultBrand {
+const GET_INAPP_BRAND = `
+query GetInAppBrand {
+  inAppBrand {
     ${brandProps}
   }
 }
@@ -58,9 +58,9 @@ export const getBrand = async (client, brandId) => {
     ? await client.query(GET_BRAND, {
         brandId,
       })
-    : await client.query(GET_DEFAULT_BRAND);
+    : await client.query(GET_INAPP_BRAND);
 
-  const brandProp = brandId ? "brand" : "defaultBrand";
+  const brandProp = brandId ? "brand" : "inAppBrand";
   const brand = results?.data?.[brandProp];
 
   const colors = brand?.settings?.colors;


### PR DESCRIPTION
## Description

Fetch default in app brand (backend falls back on default brand if default inapp isn't configured so its 100% backwards compatible)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
