### PR TITLE
list messages and message count with tags

### DIFF
--- a/packages/client-graphql/README.md
+++ b/packages/client-graphql/README.md
@@ -49,11 +49,14 @@ const getMessageCount = async (params?: {
   return messageCount;
 };
 
-const getMessages = async (params?: {
-  after?: string,
-  isRead?: boolean,
-  from?: number,
-}) => {
+const getMessages = async (
+  params?: {
+    isRead?: boolean,
+    from?: number,
+    tags?: string[],
+  },
+  after?: string
+) => {
   const { startCursor, messages } = await messagesApi.getMessages(params);
 
   return {

--- a/packages/client-graphql/src/messages/index.ts
+++ b/packages/client-graphql/src/messages/index.ts
@@ -3,11 +3,8 @@ import { ICourierClientParams } from "../types";
 import { createCourierClient } from "../client";
 
 export const GET_UNREAD_MESSAGE_COUNT = `
-  query MessageCount($isRead: Boolean, $from: Float) {
-    messageCount(params: {
-      isRead: $isRead,
-      from: $from
-    })
+  query MessageCount($params: FilterParamsInput) {
+    messageCount(params: $params)
   }
 `;
 
@@ -25,25 +22,25 @@ export const getUnreadMessageCount = (
 
   const results = await client
     .query(GET_UNREAD_MESSAGE_COUNT, {
-      ...params,
-      isRead: false,
+      params: {
+        ...params,
+        tags: ["foo"],
+        isRead: false,
+      },
     })
     .toPromise();
   return results?.data?.messageCount;
 };
 
 export interface IGetMessagesParams {
-  after?: string;
   isRead?: boolean;
   from?: number;
+  tags?: string[];
 }
 
 export const QUERY_MESSAGES = `
-  query GetMessages($after: String, $isRead: Boolean, $from: Float){
-    messages(params: { 
-        isRead: $isRead, 
-        from: $from 
-      }, after: $after) {
+  query GetMessages($params: FilterParamsInput, $limit: Int = 10, $after: String){
+    messages(params: $params, limit: $limit, after: $after) {
       totalCount
       pageInfo {
         startCursor
@@ -82,7 +79,8 @@ export const QUERY_MESSAGES = `
 `;
 
 type GetMessages = (
-  params?: IGetMessagesParams
+  params?: IGetMessagesParams,
+  after?: string
 ) => Promise<{
   appendMessages: boolean;
   startCursor: string;
@@ -90,19 +88,22 @@ type GetMessages = (
 } | void>;
 
 export const getMessages = (client?: Client): GetMessages => async (
-  params?: IGetMessagesParams
+  params?: IGetMessagesParams,
+  after?: string
 ) => {
   if (!client) {
     return Promise.resolve();
   }
 
-  const results = await client.query(QUERY_MESSAGES, params).toPromise();
+  const results = await client
+    .query(QUERY_MESSAGES, { after, params })
+    .toPromise();
 
   const messages = results?.data?.messages?.nodes;
   const startCursor = results?.data?.messages?.pageInfo?.startCursor;
 
   return {
-    appendMessages: Boolean(params?.after),
+    appendMessages: Boolean(after),
     messages,
     startCursor,
   };

--- a/packages/client-graphql/src/messages/index.ts
+++ b/packages/client-graphql/src/messages/index.ts
@@ -24,7 +24,6 @@ export const getUnreadMessageCount = (
     .query(GET_UNREAD_MESSAGE_COUNT, {
       params: {
         ...params,
-        tags: ["foo"],
         isRead: false,
       },
     })

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -187,7 +187,9 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
         return;
       }
 
-      fetchMessages(currentTab?.filters);
+      fetchMessages({
+        params: currentTab?.filters,
+      });
     },
     [isOpen, fetchMessages, currentTab]
   );

--- a/packages/react-inbox/src/components/Messages/index.tsx
+++ b/packages/react-inbox/src/components/Messages/index.tsx
@@ -63,7 +63,7 @@ const Messages: React.ForwardRefExoticComponent<
       }
 
       fetchMessages({
-        ...currentTab?.filters,
+        params: currentTab?.filters,
         after: startCursor,
       });
     },

--- a/packages/react-inbox/src/hooks/use-inbox-actions.ts
+++ b/packages/react-inbox/src/hooks/use-inbox-actions.ts
@@ -84,15 +84,18 @@ const useInboxActions = () => {
       });
     },
 
-    fetchMessages: (params?: IGetMessagesParams) => {
-      const meta = {
+    fetchMessages: (payload: {
+      params?: IGetMessagesParams;
+      after?: string;
+    }) => {
+      const params = {
         from: inbox?.from,
-        ...params,
+        ...payload.params,
       };
       dispatch({
         type: "inbox/FETCH_MESSAGES",
-        payload: () => messages.getMessages(meta),
-        meta,
+        payload: () => messages.getMessages(params, payload.after),
+        meta: payload,
       });
     },
 

--- a/packages/react-provider/src/transports/types.ts
+++ b/packages/react-provider/src/transports/types.ts
@@ -17,6 +17,7 @@ export interface ICourierMessage {
   icon?: string | false;
   title?: string | React.ReactElement;
   data?: {
+    channel?: string;
     brandId?: string;
     trackingIds?: {
       channelTrackingId?: string;


### PR DESCRIPTION
## Description

support `tags` as a filter param in our graphql calls

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
