### PR TITLE
Riley/c 5860 support banners in client graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     ]
   },
   "dependencies": {
-    "babel-plugin-transform-inline-environment-variables": "^0.4.3"
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
+    "isomorphic-fetch": "^3.0.0"
   }
 }

--- a/packages/client-graphql/README.md
+++ b/packages/client-graphql/README.md
@@ -107,7 +107,7 @@ import { Banner } from "@trycourier/client-graphql";
 const bannerApi = Banner({
   clientKey: "abc123",
   userId: "@me",
-  userSignature: "SUPER_SECRET",
+  userSignature: "SUPER_SECRET", //optional
 });
 
 const getBanners = async (params?: { tags?: string[], locale?: string }) => {
@@ -121,6 +121,7 @@ const getBanners = async (params?: { tags?: string[], locale?: string }) => {
 ```js
 import { Banner } from "@trycourier/client-graphql";
 const bannerApi = Banner({
+  clientKey: "abc123",
   authorization: "MY JWT TOKEN",
 });
 

--- a/packages/client-graphql/README.md
+++ b/packages/client-graphql/README.md
@@ -97,3 +97,35 @@ const getBrand = async (brandId?: string) => {
   return myBrand;
 };
 ```
+
+### Banners
+
+#### For one user
+
+```js
+import { Banner } from "@trycourier/client-graphql";
+const bannerApi = Banner({
+  clientKey: "abc123",
+  userId: "@me",
+  userSignature: "SUPER_SECRET",
+});
+
+const getBanners = async (params?: { tags?: string[], locale?: string }) => {
+  const myBanners = await bannerApi.getBanners(params);
+  return myBanners;
+};
+```
+
+#### For > 1 user
+
+```js
+import { Banner } from "@trycourier/client-graphql";
+const bannerApi = Banner({
+  authorization: "MY JWT TOKEN",
+});
+
+const getBanners = async (params?: { tags?: string[], locale?: string }) => {
+  const myBanners = await bannerApi.getBanners(params);
+  return myBanners;
+};
+```

--- a/packages/client-graphql/__tests__/banner.spec.ts
+++ b/packages/client-graphql/__tests__/banner.spec.ts
@@ -34,6 +34,7 @@ describe("banner", () => {
     fetchMock.mockImplementation(() => Promise.resolve([]));
     const bannerApi = Banner({
       authorization: "abc123",
+      clientKey: "CLIENT_KEY",
     });
 
     await bannerApi.getBanners({
@@ -48,6 +49,7 @@ describe("banner", () => {
     );
     expect(thisCall.headers).toEqual({
       authorization: "abc123",
+      "x-courier-client-key": "CLIENT_KEY",
       "content-type": "application/json",
     });
     expect(thisCall.method).toBe("POST");

--- a/packages/client-graphql/__tests__/banner.spec.ts
+++ b/packages/client-graphql/__tests__/banner.spec.ts
@@ -1,7 +1,7 @@
-//global.fetch = jest.fn();
+global.fetch = jest.fn();
 require("isomorphic-fetch");
 
-//const fetchMock = global.fetch as jest.Mock;
+const fetchMock = global.fetch as jest.Mock;
 import Banner from "../src/banner";
 
 describe("banner", () => {
@@ -9,133 +9,49 @@ describe("banner", () => {
     jest.clearAllMocks();
   });
 
-  test("works", async () => {
+  test("creates query correctly with hmac", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
     const bannerApi = Banner({
-      apiUrl: "https://rubmz24skk.execute-api.us-east-1.amazonaws.com/dev",
-      clientKey: "MDE0ZDMwZDYtMjlkMS00ZTI1LTk0MTctNzQ1NTljN2I1YTk2",
-      userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
+      clientKey: "CLIENT_KEY",
+      userId: "USER_ID",
     });
 
-    const result = await bannerApi.getBanner();
+    await bannerApi.getBanners();
 
-    console.log("result", JSON.stringify(result, null, 2));
-
-    expect(result).toMatchInlineSnapshot(`
+    expect(fetchMock.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
-        "appendMessages": false,
-        "banner": Array [
-          Object {
-            "__typename": "Messages",
-            "content": Object {
-              "__typename": "Content",
-              "blocks": Array [
-                Object {
-                  "__typename": "TextBlock",
-                  "text": "world",
-                  "type": "text",
-                },
-              ],
-              "body": "world
-      ",
-              "data": null,
-              "title": "hello",
-              "trackingIds": null,
-            },
-            "created": "2022-04-19T23:41:58.003Z",
-            "id": "eyJpZCI6IjEtNjI1ZjQ4YzUtM2ZlNjRkZDAxMjZjMzZjMTg0MzhhZTVhIiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
-            "messageId": "1-625f48c5-3fe64dd0126c36c18438ae5a",
-            "tags": Array [],
-          },
-          Object {
-            "__typename": "Messages",
-            "content": Object {
-              "__typename": "Content",
-              "blocks": Array [
-                Object {
-                  "__typename": "TextBlock",
-                  "text": "world",
-                  "type": "text",
-                },
-              ],
-              "body": "world
-      ",
-              "data": null,
-              "title": "hello",
-              "trackingIds": null,
-            },
-            "created": "2022-04-19T23:40:48.023Z",
-            "id": "eyJpZCI6IjEtNjI1ZjQ4N2YtZjE4NzZhMWY1OWU0OTA1ODEzNTg1MTFlIiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
-            "messageId": "1-625f487f-f1876a1f59e490581358511e",
-            "tags": Array [],
-          },
-          Object {
-            "__typename": "Messages",
-            "content": Object {
-              "__typename": "Content",
-              "blocks": Array [
-                Object {
-                  "__typename": "TextBlock",
-                  "text": "world",
-                  "type": "text",
-                },
-              ],
-              "body": "world
-      ",
-              "data": null,
-              "title": "hello",
-              "trackingIds": null,
-            },
-            "created": "2022-04-19T23:38:24.754Z",
-            "id": "eyJpZCI6IjEtNjI1ZjQ3ZWUtNzkyYTMxMDhiOTU0NjQ5MDg0MWVmMDk5Iiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
-            "messageId": "1-625f47ee-792a3108b9546490841ef099",
-            "tags": Array [],
-          },
-          Object {
-            "__typename": "Messages",
-            "content": Object {
-              "__typename": "Content",
-              "blocks": Array [
-                Object {
-                  "__typename": "TextBlock",
-                  "text": "world",
-                  "type": "text",
-                },
-              ],
-              "body": "world
-      ",
-              "data": null,
-              "title": "hello",
-              "trackingIds": null,
-            },
-            "created": "2022-04-19T23:27:44.607Z",
-            "id": "eyJpZCI6IjEtNjI1ZjQ1NmQtZjAyODgwOTRkODhlYTVjZDFmZjBhMWY0Iiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
-            "messageId": "1-625f456d-f0288094d88ea5cd1ff0a1f4",
-            "tags": Array [],
-          },
-          Object {
-            "__typename": "Messages",
-            "content": Object {
-              "__typename": "Content",
-              "blocks": Array [
-                Object {
-                  "__typename": "TextBlock",
-                  "text": "world",
-                  "type": "text",
-                },
-              ],
-              "body": "world
-      ",
-              "data": null,
-              "title": "hello",
-              "trackingIds": null,
-            },
-            "created": "2022-04-19T20:48:40.232Z",
-            "id": "eyJpZCI6IjEtNjI1ZjIwMjUtNjNiMDNmOWMxZmM3ODBkODQ3Yjc1YTE3Iiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
-            "messageId": "1-625f2025-63b03f9c1fc780d847b75a17",
-            "tags": Array [],
-          },
-        ],
-        "startCursor": null,
+        "body": "{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        trackingIds {\\\\n          clickTrackingId\\\\n          deliverTrackingId\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{}}",
+        "headers": Object {
+          "content-type": "application/json",
+          "x-courier-client-key": "CLIENT_KEY",
+          "x-courier-user-id": "USER_ID",
+        },
+        "method": "POST",
+        "signal": AbortSignal {},
+      }
+    `);
+  });
+
+  test("creates query correctly with jwt", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+    const bannerApi = Banner({
+      authorization: "abc123",
+    });
+
+    await bannerApi.getBanners({
+      from: 123,
+      tags: ["abc"],
+    });
+
+    expect(fetchMock.mock.calls[0][1]).toMatchInlineSnapshot(`
+      Object {
+        "body": "{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        trackingIds {\\\\n          clickTrackingId\\\\n          deliverTrackingId\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{\\"params\\":{\\"from\\":123,\\"tags\\":[\\"abc\\"]}}}",
+        "headers": Object {
+          "authorization": "abc123",
+          "content-type": "application/json",
+        },
+        "method": "POST",
+        "signal": AbortSignal {},
       }
     `);
   });

--- a/packages/client-graphql/__tests__/banner.spec.ts
+++ b/packages/client-graphql/__tests__/banner.spec.ts
@@ -1,0 +1,142 @@
+//global.fetch = jest.fn();
+require("isomorphic-fetch");
+
+//const fetchMock = global.fetch as jest.Mock;
+import Banner from "../src/banner";
+
+describe("banner", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("works", async () => {
+    const bannerApi = Banner({
+      apiUrl: "https://rubmz24skk.execute-api.us-east-1.amazonaws.com/dev",
+      clientKey: "MDE0ZDMwZDYtMjlkMS00ZTI1LTk0MTctNzQ1NTljN2I1YTk2",
+      userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
+    });
+
+    const result = await bannerApi.getBanner();
+
+    console.log("result", JSON.stringify(result, null, 2));
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "appendMessages": false,
+        "banner": Array [
+          Object {
+            "__typename": "Messages",
+            "content": Object {
+              "__typename": "Content",
+              "blocks": Array [
+                Object {
+                  "__typename": "TextBlock",
+                  "text": "world",
+                  "type": "text",
+                },
+              ],
+              "body": "world
+      ",
+              "data": null,
+              "title": "hello",
+              "trackingIds": null,
+            },
+            "created": "2022-04-19T23:41:58.003Z",
+            "id": "eyJpZCI6IjEtNjI1ZjQ4YzUtM2ZlNjRkZDAxMjZjMzZjMTg0MzhhZTVhIiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
+            "messageId": "1-625f48c5-3fe64dd0126c36c18438ae5a",
+            "tags": Array [],
+          },
+          Object {
+            "__typename": "Messages",
+            "content": Object {
+              "__typename": "Content",
+              "blocks": Array [
+                Object {
+                  "__typename": "TextBlock",
+                  "text": "world",
+                  "type": "text",
+                },
+              ],
+              "body": "world
+      ",
+              "data": null,
+              "title": "hello",
+              "trackingIds": null,
+            },
+            "created": "2022-04-19T23:40:48.023Z",
+            "id": "eyJpZCI6IjEtNjI1ZjQ4N2YtZjE4NzZhMWY1OWU0OTA1ODEzNTg1MTFlIiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
+            "messageId": "1-625f487f-f1876a1f59e490581358511e",
+            "tags": Array [],
+          },
+          Object {
+            "__typename": "Messages",
+            "content": Object {
+              "__typename": "Content",
+              "blocks": Array [
+                Object {
+                  "__typename": "TextBlock",
+                  "text": "world",
+                  "type": "text",
+                },
+              ],
+              "body": "world
+      ",
+              "data": null,
+              "title": "hello",
+              "trackingIds": null,
+            },
+            "created": "2022-04-19T23:38:24.754Z",
+            "id": "eyJpZCI6IjEtNjI1ZjQ3ZWUtNzkyYTMxMDhiOTU0NjQ5MDg0MWVmMDk5Iiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
+            "messageId": "1-625f47ee-792a3108b9546490841ef099",
+            "tags": Array [],
+          },
+          Object {
+            "__typename": "Messages",
+            "content": Object {
+              "__typename": "Content",
+              "blocks": Array [
+                Object {
+                  "__typename": "TextBlock",
+                  "text": "world",
+                  "type": "text",
+                },
+              ],
+              "body": "world
+      ",
+              "data": null,
+              "title": "hello",
+              "trackingIds": null,
+            },
+            "created": "2022-04-19T23:27:44.607Z",
+            "id": "eyJpZCI6IjEtNjI1ZjQ1NmQtZjAyODgwOTRkODhlYTVjZDFmZjBhMWY0Iiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
+            "messageId": "1-625f456d-f0288094d88ea5cd1ff0a1f4",
+            "tags": Array [],
+          },
+          Object {
+            "__typename": "Messages",
+            "content": Object {
+              "__typename": "Content",
+              "blocks": Array [
+                Object {
+                  "__typename": "TextBlock",
+                  "text": "world",
+                  "type": "text",
+                },
+              ],
+              "body": "world
+      ",
+              "data": null,
+              "title": "hello",
+              "trackingIds": null,
+            },
+            "created": "2022-04-19T20:48:40.232Z",
+            "id": "eyJpZCI6IjEtNjI1ZjIwMjUtNjNiMDNmOWMxZmM3ODBkODQ3Yjc1YTE3Iiwib2JqdHlwZSI6Im1lc3NhZ2VzIn0",
+            "messageId": "1-625f2025-63b03f9c1fc780d847b75a17",
+            "tags": Array [],
+          },
+        ],
+        "startCursor": null,
+      }
+    `);
+  });
+});

--- a/packages/client-graphql/__tests__/banner.spec.ts
+++ b/packages/client-graphql/__tests__/banner.spec.ts
@@ -18,18 +18,16 @@ describe("banner", () => {
 
     await bannerApi.getBanners();
 
-    expect(fetchMock.mock.calls[0][1]).toMatchInlineSnapshot(`
-      Object {
-        "body": "{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        trackingIds {\\\\n          clickTrackingId\\\\n          deliverTrackingId\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{}}",
-        "headers": Object {
-          "content-type": "application/json",
-          "x-courier-client-key": "CLIENT_KEY",
-          "x-courier-user-id": "USER_ID",
-        },
-        "method": "POST",
-        "signal": AbortSignal {},
-      }
-    `);
+    const thisCall = fetchMock.mock.calls[0][1];
+    expect(thisCall.body).toMatchInlineSnapshot(
+      `"{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      userId\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{}}"`
+    );
+    expect(thisCall.headers).toEqual({
+      "content-type": "application/json",
+      "x-courier-client-key": "CLIENT_KEY",
+      "x-courier-user-id": "USER_ID",
+    });
+    expect(thisCall.method).toBe("POST");
   });
 
   test("creates query correctly with jwt", async () => {
@@ -44,16 +42,14 @@ describe("banner", () => {
       tags: ["abc"],
     });
 
-    expect(fetchMock.mock.calls[0][1]).toMatchInlineSnapshot(`
-      Object {
-        "body": "{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        trackingIds {\\\\n          clickTrackingId\\\\n          deliverTrackingId\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{\\"params\\":{\\"from\\":123,\\"locale\\":\\"eu-fr\\",\\"tags\\":[\\"abc\\"]}}}",
-        "headers": Object {
-          "authorization": "abc123",
-          "content-type": "application/json",
-        },
-        "method": "POST",
-        "signal": AbortSignal {},
-      }
-    `);
+    const thisCall = fetchMock.mock.calls[0][1];
+    expect(thisCall.body).toMatchInlineSnapshot(
+      `"{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      userId\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{\\"params\\":{\\"from\\":123,\\"locale\\":\\"eu-fr\\",\\"tags\\":[\\"abc\\"]}}}"`
+    );
+    expect(thisCall.headers).toEqual({
+      authorization: "abc123",
+      "content-type": "application/json",
+    });
+    expect(thisCall.method).toBe("POST");
   });
 });

--- a/packages/client-graphql/__tests__/banner.spec.ts
+++ b/packages/client-graphql/__tests__/banner.spec.ts
@@ -40,12 +40,13 @@ describe("banner", () => {
 
     await bannerApi.getBanners({
       from: 123,
+      locale: "eu-fr",
       tags: ["abc"],
     });
 
     expect(fetchMock.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
-        "body": "{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        trackingIds {\\\\n          clickTrackingId\\\\n          deliverTrackingId\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{\\"params\\":{\\"from\\":123,\\"tags\\":[\\"abc\\"]}}}",
+        "body": "{\\"query\\":\\"query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String) {\\\\n  banners(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      id\\\\n      messageId\\\\n      created\\\\n      tags\\\\n      content {\\\\n        title\\\\n        body\\\\n        blocks {\\\\n          ... on TextBlock {\\\\n            type\\\\n            text\\\\n            __typename\\\\n          }\\\\n          ... on ActionBlock {\\\\n            type\\\\n            text\\\\n            url\\\\n            __typename\\\\n          }\\\\n          __typename\\\\n        }\\\\n        data\\\\n        trackingIds {\\\\n          clickTrackingId\\\\n          deliverTrackingId\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetBanners\\",\\"variables\\":{\\"params\\":{\\"from\\":123,\\"locale\\":\\"eu-fr\\",\\"tags\\":[\\"abc\\"]}}}",
         "headers": Object {
           "authorization": "abc123",
           "content-type": "application/json",

--- a/packages/client-graphql/__tests__/index.spec.ts
+++ b/packages/client-graphql/__tests__/index.spec.ts
@@ -2,6 +2,7 @@ global.fetch = jest.fn();
 
 const fetchMock = global.fetch as jest.Mock;
 import Messages from "../src/messages";
+import Banner from "../src/banner";
 
 describe("getMessages", () => {
   afterEach(() => {
@@ -108,5 +109,19 @@ describe("getMessageCount", () => {
         "signal": AbortSignal {},
       }
     `);
+  });
+});
+
+describe("test123", () => {
+  test("works", async () => {
+    const bannerApi = Banner({
+      apiUrl: "https://rubmz24skk.execute-api.us-east-1.amazonaws.com/dev",
+      clientKey: "MDE0ZDMwZDYtMjlkMS00ZTI1LTk0MTctNzQ1NTljN2I1YTk2",
+      userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
+    });
+
+    const result = await bannerApi.getBanner();
+
+    console.log("result", result);
   });
 });

--- a/packages/client-graphql/__tests__/index.spec.ts
+++ b/packages/client-graphql/__tests__/index.spec.ts
@@ -2,7 +2,6 @@ global.fetch = jest.fn();
 
 const fetchMock = global.fetch as jest.Mock;
 import Messages from "../src/messages";
-import Banner from "../src/banner";
 
 describe("getMessages", () => {
   afterEach(() => {
@@ -109,19 +108,5 @@ describe("getMessageCount", () => {
         "signal": AbortSignal {},
       }
     `);
-  });
-});
-
-describe("test123", () => {
-  test("works", async () => {
-    const bannerApi = Banner({
-      apiUrl: "https://rubmz24skk.execute-api.us-east-1.amazonaws.com/dev",
-      clientKey: "MDE0ZDMwZDYtMjlkMS00ZTI1LTk0MTctNzQ1NTljN2I1YTk2",
-      userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
-    });
-
-    const result = await bannerApi.getBanner();
-
-    console.log("result", result);
   });
 });

--- a/packages/client-graphql/src/banner/index.ts
+++ b/packages/client-graphql/src/banner/index.ts
@@ -1,0 +1,88 @@
+import { Client } from "urql";
+import { ICourierClientParams } from "../types";
+import { createCourierClient } from "../client";
+
+export interface IGetBannerParams {
+  from?: number;
+  tags?: string[];
+}
+
+export const QUERY_BANNER = `
+  query GetBanner($params: FilterParamsInput, $limit: Int = 10, $after: String){
+    banner(params: $params, limit: $limit, after: $after) {
+      totalCount
+      pageInfo {
+        startCursor
+        hasNextPage
+      }
+      nodes {
+        id
+        messageId
+        created
+        tags
+        content {
+          title
+          body
+          blocks {
+            ... on TextBlock {
+              type
+              text
+            }
+            ... on ActionBlock {
+              type
+              text
+              url
+            }
+          }
+          data
+          trackingIds {
+            clickTrackingId
+            deliverTrackingId
+          }
+        }
+      }
+    }
+  }
+`;
+
+type GetBanner = (
+  params?: IGetBannerParams,
+  after?: string
+) => Promise<{
+  startCursor: string;
+  banner: any[];
+} | void>;
+
+export const getBanner = (client?: Client): GetBanner => async (
+  params?: IGetBannerParams,
+  after?: string
+) => {
+  if (!client) {
+    return Promise.resolve();
+  }
+
+  const results = await client
+    .query(QUERY_BANNER, { after, params })
+    .toPromise();
+
+  const banner = results?.data?.banner?.nodes;
+  const startCursor = results?.data?.banner?.pageInfo?.startCursor;
+
+  return {
+    appendMessages: Boolean(after),
+    banner,
+    startCursor,
+  };
+};
+
+export default (
+  params: ICourierClientParams | { client: Client }
+): {
+  getBanner: GetBanner;
+} => {
+  const client = createCourierClient(params);
+
+  return {
+    getBanner: getBanner(client),
+  };
+};

--- a/packages/client-graphql/src/banner/index.ts
+++ b/packages/client-graphql/src/banner/index.ts
@@ -4,6 +4,7 @@ import { createCourierClient } from "../client";
 
 export interface IGetBannerParams {
   from?: number;
+  locale?: string;
   tags?: string[];
 }
 

--- a/packages/client-graphql/src/banner/index.ts
+++ b/packages/client-graphql/src/banner/index.ts
@@ -8,8 +8,8 @@ export interface IGetBannerParams {
 }
 
 export const QUERY_BANNER = `
-  query GetBanner($params: FilterParamsInput, $limit: Int = 10, $after: String){
-    banner(params: $params, limit: $limit, after: $after) {
+  query GetBanners($params: BannerParamsInput, $limit: Int = 10, $after: String){
+    banners(params: $params, limit: $limit, after: $after) {
       totalCount
       pageInfo {
         startCursor
@@ -45,15 +45,15 @@ export const QUERY_BANNER = `
   }
 `;
 
-type GetBanner = (
+type GetBanners = (
   params?: IGetBannerParams,
   after?: string
 ) => Promise<{
   startCursor: string;
-  banner: any[];
+  banners: any[];
 } | void>;
 
-export const getBanner = (client?: Client): GetBanner => async (
+export const getBanners = (client?: Client): GetBanners => async (
   params?: IGetBannerParams,
   after?: string
 ) => {
@@ -65,12 +65,12 @@ export const getBanner = (client?: Client): GetBanner => async (
     .query(QUERY_BANNER, { after, params })
     .toPromise();
 
-  const banner = results?.data?.banner?.nodes;
-  const startCursor = results?.data?.banner?.pageInfo?.startCursor;
+  const banners = results?.data?.banners?.nodes;
+  const startCursor = results?.data?.banners?.pageInfo?.startCursor;
 
   return {
     appendMessages: Boolean(after),
-    banner,
+    banners,
     startCursor,
   };
 };
@@ -78,11 +78,11 @@ export const getBanner = (client?: Client): GetBanner => async (
 export default (
   params: ICourierClientParams | { client: Client }
 ): {
-  getBanner: GetBanner;
+  getBanners: GetBanners;
 } => {
   const client = createCourierClient(params);
 
   return {
-    getBanner: getBanner(client),
+    getBanners: getBanners(client),
   };
 };

--- a/packages/client-graphql/src/banner/index.ts
+++ b/packages/client-graphql/src/banner/index.ts
@@ -18,6 +18,7 @@ export const QUERY_BANNER = `
       }
       nodes {
         id
+        userId
         messageId
         created
         tags
@@ -36,10 +37,6 @@ export const QUERY_BANNER = `
             }
           }
           data
-          trackingIds {
-            clickTrackingId
-            deliverTrackingId
-          }
         }
       }
     }

--- a/packages/client-graphql/src/brands/index.ts
+++ b/packages/client-graphql/src/brands/index.ts
@@ -100,7 +100,7 @@ export const getBrand = (client?: Client): GetBrand => async (brandId) => {
 };
 
 export default (
-  params: ICourierClientBasicParams | { client: Client }
+  params: ICourierClientBasicParams | { client?: Client }
 ): {
   getBrand: GetBrand;
 } => {

--- a/packages/client-graphql/src/brands/index.ts
+++ b/packages/client-graphql/src/brands/index.ts
@@ -1,4 +1,4 @@
-import { ICourierClientParams } from "./../types";
+import { ICourierClientBasicParams } from "./../types";
 import { Client } from "urql";
 import { createCourierClient } from "../client";
 
@@ -100,7 +100,7 @@ export const getBrand = (client?: Client): GetBrand => async (brandId) => {
 };
 
 export default (
-  params: ICourierClientParams
+  params: ICourierClientBasicParams | { client: Client }
 ): {
   getBrand: GetBrand;
 } => {

--- a/packages/client-graphql/src/client.ts
+++ b/packages/client-graphql/src/client.ts
@@ -22,6 +22,7 @@ export const createCourierClient = (
 
   if ("authorization" in params) {
     headers = {
+      "x-courier-client-key": params.clientKey,
       authorization: params.authorization,
     } as CourierJWTHeaders;
   } else {

--- a/packages/client-graphql/src/client.ts
+++ b/packages/client-graphql/src/client.ts
@@ -11,7 +11,8 @@ export const createCourierClient = (
     | ICourierClientBasicParams
     | ICourierClientJWTParams
     | {
-        client: Client;
+        client?: Client;
+        apiUrl?: string;
       }
 ): Client | undefined => {
   if ("client" in params) {

--- a/packages/client-graphql/src/events/index.ts
+++ b/packages/client-graphql/src/events/index.ts
@@ -47,7 +47,7 @@ export const trackEventBatch = (client?: Client): TrackEventBatch => async (
 };
 
 export default (
-  params: ICourierClientBasicParams | { client: Client }
+  params: ICourierClientBasicParams | { client?: Client }
 ): {
   trackEvent: TrackEvent;
   trackEventBatch: TrackEventBatch;

--- a/packages/client-graphql/src/events/index.ts
+++ b/packages/client-graphql/src/events/index.ts
@@ -1,5 +1,5 @@
 import { Client } from "urql";
-import { ICourierClientParams } from "../types";
+import { ICourierClientBasicParams } from "../types";
 import { createCourierClient } from "../client";
 
 const TRACK_EVENT = `
@@ -47,7 +47,7 @@ export const trackEventBatch = (client?: Client): TrackEventBatch => async (
 };
 
 export default (
-  params: ICourierClientParams
+  params: ICourierClientBasicParams | { client: Client }
 ): {
   trackEvent: TrackEvent;
   trackEventBatch: TrackEventBatch;

--- a/packages/client-graphql/src/index.ts
+++ b/packages/client-graphql/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Brands } from "./brands";
+export { default as Banner } from "./banner";
 export { default as Messages } from "./messages";
 export { default as Events } from "./events";
 export { default as Preferences } from "./preferences";

--- a/packages/client-graphql/src/messages/index.ts
+++ b/packages/client-graphql/src/messages/index.ts
@@ -111,7 +111,7 @@ export const getMessages = (client?: Client): GetMessages => async (
 };
 
 export default (
-  params: ICourierClientBasicParams | { client: Client }
+  params: ICourierClientBasicParams | { client?: Client }
 ): {
   getMessageCount: GetMessageCount;
   getMessages: GetMessages;

--- a/packages/client-graphql/src/messages/index.ts
+++ b/packages/client-graphql/src/messages/index.ts
@@ -1,5 +1,5 @@
 import { Client } from "urql";
-import { ICourierClientParams } from "../types";
+import { ICourierClientBasicParams } from "../types";
 import { createCourierClient } from "../client";
 
 export const GET_MESSAGE_COUNT = `
@@ -111,7 +111,7 @@ export const getMessages = (client?: Client): GetMessages => async (
 };
 
 export default (
-  params: ICourierClientParams | { client: Client }
+  params: ICourierClientBasicParams | { client: Client }
 ): {
   getMessageCount: GetMessageCount;
   getMessages: GetMessages;

--- a/packages/client-graphql/src/preferences/index.ts
+++ b/packages/client-graphql/src/preferences/index.ts
@@ -1,5 +1,5 @@
 import { Client } from "urql";
-import { ICourierClientParams } from "../types";
+import { ICourierClientBasicParams } from "../types";
 import { createCourierClient } from "../client";
 
 const RECIPIENT_PREFERENCES = `
@@ -53,7 +53,7 @@ export const updateRecipientPreferences = (
 };
 
 export default (
-  params: ICourierClientParams | { client: Client }
+  params: ICourierClientBasicParams | { client: Client }
 ): {
   getRecipientPreferences: GetRecipientPreferences;
   updateRecipientPreferences: UpdateRecipientPreferences;

--- a/packages/client-graphql/src/preferences/index.ts
+++ b/packages/client-graphql/src/preferences/index.ts
@@ -53,7 +53,7 @@ export const updateRecipientPreferences = (
 };
 
 export default (
-  params: ICourierClientBasicParams | { client: Client }
+  params: ICourierClientBasicParams | { client?: Client }
 ): {
   getRecipientPreferences: GetRecipientPreferences;
   updateRecipientPreferences: UpdateRecipientPreferences;

--- a/packages/client-graphql/src/types.ts
+++ b/packages/client-graphql/src/types.ts
@@ -1,15 +1,29 @@
 import { Client } from "urql";
 
-export type ICourierClientParams = {
+export type ICourierClientBasicParams = {
   client?: Client;
-  clientKey?: string;
-  userId?: string;
+  clientKey: string;
+  userId: string;
   userSignature?: string;
   apiUrl?: string;
 };
 
-export interface ICourierHeaders {
+export type ICourierClientJWTParams = {
+  client?: Client;
+  authorization: string;
+  apiUrl?: string;
+};
+
+export type ICourierClientParams =
+  | ICourierClientBasicParams
+  | ICourierClientJWTParams;
+
+export type CourierBasicHeaders = RequestInit["headers"] & {
   "x-courier-client-key": string;
   "x-courier-user-id": string;
   "x-courier-user-signature"?: string;
-}
+};
+
+export type CourierJWTHeaders = RequestInit["headers"] & {
+  authorization: string;
+};

--- a/packages/client-graphql/src/types.ts
+++ b/packages/client-graphql/src/types.ts
@@ -11,6 +11,7 @@ export type ICourierClientBasicParams = {
 export type ICourierClientJWTParams = {
   client?: Client;
   authorization: string;
+  clientKey: string;
   apiUrl?: string;
 };
 
@@ -25,5 +26,6 @@ export type CourierBasicHeaders = RequestInit["headers"] & {
 };
 
 export type CourierJWTHeaders = RequestInit["headers"] & {
+  "x-courier-client-key": string;
   authorization: string;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10807,6 +10807,14 @@ isobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -18585,6 +18593,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
## Description

adds the `getBanners` graphql query to the client graphql and support jwt token


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
