### PR TITLE
allow updating tabs through props

### DIFF
--- a/packages/react-hooks/src/inbox/reducer.ts
+++ b/packages/react-hooks/src/inbox/reducer.ts
@@ -45,7 +45,8 @@ export default (state: IInbox = initialState, action): IInbox => {
     case "inbox/SET_CURRENT_TAB": {
       return {
         ...state,
-        messages: state.currentTab !== action.payload ? [] : state.messages,
+        messages:
+          state.currentTab?.id !== action.payload?.id ? [] : state.messages,
         currentTab: action.payload,
       };
     }

--- a/packages/react-hooks/src/inbox/reducer.ts
+++ b/packages/react-hooks/src/inbox/reducer.ts
@@ -1,20 +1,5 @@
 import { IMessage, IInbox } from "./types";
 
-export const DEFAULT_TABS = [
-  {
-    id: "unread",
-    label: "Unread",
-    filters: {
-      isRead: false,
-    },
-  },
-  {
-    id: "all",
-    label: "All Messages",
-    filters: {},
-  },
-];
-
 const makeMessage = (message): IMessage => ({
   blocks: message?.content?.blocks,
   body: message?.content?.body,
@@ -31,8 +16,6 @@ const initialState: IInbox = {
   messages: [],
   view: "messages",
   unreadMessageCount: 0,
-  tabs: DEFAULT_TABS,
-  currentTab: DEFAULT_TABS[0],
 };
 
 export default (state: IInbox = initialState, action): IInbox => {
@@ -62,8 +45,7 @@ export default (state: IInbox = initialState, action): IInbox => {
     case "inbox/SET_CURRENT_TAB": {
       return {
         ...state,
-        messages:
-          state.currentTab?.id !== action.payload?.id ? [] : state.messages,
+        messages: state.currentTab !== action.payload ? [] : state.messages,
         currentTab: action.payload,
       };
     }

--- a/packages/react-hooks/src/inbox/types.ts
+++ b/packages/react-hooks/src/inbox/types.ts
@@ -31,7 +31,6 @@ export interface IMessage {
 export interface IInbox {
   brand?: Brand;
   isOpen?: boolean;
-  tabs?: ITab[];
   currentTab?: ITab;
   isLoading?: boolean;
   messages?: Array<IMessage>;

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -90,6 +90,20 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
   props = useMemo(() => {
     return {
       openLinksInNewTab: true,
+      tabs: props.tabs ?? [
+        {
+          id: "unread",
+          label: "Unread",
+          filters: {
+            isRead: false,
+          },
+        },
+        {
+          id: "all",
+          label: "All Messages",
+          filters: {},
+        },
+      ],
       ...props,
     };
   }, [props]);

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -90,7 +90,7 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
   props = useMemo(() => {
     return {
       openLinksInNewTab: true,
-      tabs: props.tabs ?? [
+      tabs: [
         {
           id: "unread",
           label: "Unread",

--- a/packages/react-inbox/src/components/Messages/index.tsx
+++ b/packages/react-inbox/src/components/Messages/index.tsx
@@ -44,6 +44,7 @@ const Messages: React.ForwardRefExoticComponent<
       renderMessage,
       renderNoMessages,
       renderTabs,
+      tabs,
       title = "Inbox",
     },
     ref
@@ -58,7 +59,6 @@ const Messages: React.ForwardRefExoticComponent<
       markAllAsRead,
       messages = [],
       startCursor,
-      tabs,
       toggleInbox,
       unreadMessageCount,
       view,
@@ -116,7 +116,11 @@ const Messages: React.ForwardRefExoticComponent<
           )}
           {view === "messages" ? (
             <>
-              {renderTabs ? renderTabs({ tabs, currentTab }) : <TabList />}
+              {renderTabs ? (
+                renderTabs({ tabs, currentTab })
+              ) : (
+                <TabList labels={labels} tabs={tabs} currentTab={currentTab} />
+              )}
               <MessageList
                 ref={messageListRef}
                 isMobile={isMobile}

--- a/packages/react-inbox/src/components/TabList/index.tsx
+++ b/packages/react-inbox/src/components/TabList/index.tsx
@@ -2,9 +2,14 @@ import React from "react";
 import classNames from "classnames";
 import { Container, Tab } from "./styled";
 import { useInbox } from "@trycourier/react-hooks";
+import { InboxProps, ITab } from "~/types";
 
-const TabList: React.FunctionComponent = () => {
-  const { setCurrentTab, currentTab, tabs } = useInbox();
+const TabList: React.FunctionComponent<{
+  tabs?: ITab[];
+  currentTab?: ITab;
+  labels?: InboxProps["labels"];
+}> = ({ tabs, currentTab, labels }) => {
+  const { setCurrentTab } = useInbox();
 
   const handleOnChange = (newTab) => (event: React.MouseEvent) => {
     event.preventDefault();
@@ -13,7 +18,7 @@ const TabList: React.FunctionComponent = () => {
 
   return (
     <Container>
-      {tabs?.map((tab) => (
+      {tabs?.map((tab, index) => (
         <Tab
           key={tab.id}
           className={classNames({
@@ -21,7 +26,7 @@ const TabList: React.FunctionComponent = () => {
           })}
           onClick={handleOnChange(tab)}
         >
-          {tab.label}
+          {labels?.tabs?.[index] ?? tab.label}
         </Tab>
       ))}
     </Container>

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -17,11 +17,12 @@ export interface InboxProps {
   isOpen?: boolean;
   formatDate?: (isoDate: string) => string;
   labels?: {
-    markAsRead?: string;
-    markAsUnread?: string;
-    markAllAsRead?: string;
     backToInbox?: string;
     emptyState?: string;
+    markAllAsRead?: string;
+    markAsRead?: string;
+    markAsUnread?: string;
+    tabs?: string[];
   };
   openLinksInNewTab?: boolean;
   placement?: TippyProps["placement"];


### PR DESCRIPTION
## Description

tabs were stored in reducer/context which meant they couldn't be updated via props.  we need them to be updated via props for localization

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
