### PR TITLE
add new inbox to clientgraphql

### DIFF
--- a/packages/client-graphql/babel.config.js
+++ b/packages/client-graphql/babel.config.js
@@ -12,5 +12,4 @@ module.exports = {
     ],
   ].filter(Boolean),
   presets: ["@babel/preset-typescript", "@babel/preset-env"],
-  ignore: ["src/__tests__", "src/__mocks__"],
 };

--- a/packages/client-graphql/src/__tests__/banner.spec.ts
+++ b/packages/client-graphql/src/__tests__/banner.spec.ts
@@ -2,7 +2,7 @@ global.fetch = jest.fn();
 require("isomorphic-fetch");
 
 const fetchMock = global.fetch as jest.Mock;
-import Banner from "../src/banner";
+import Banner from "../banner";
 
 describe("banner", () => {
   afterEach(() => {

--- a/packages/client-graphql/src/__tests__/index.spec.ts
+++ b/packages/client-graphql/src/__tests__/index.spec.ts
@@ -1,7 +1,7 @@
 global.fetch = jest.fn();
 
 const fetchMock = global.fetch as jest.Mock;
-import Messages from "../src/messages";
+import Messages from "../messages";
 
 describe("getMessages", () => {
   afterEach(() => {

--- a/packages/client-graphql/src/banner.ts
+++ b/packages/client-graphql/src/banner.ts
@@ -1,6 +1,6 @@
 import { Client } from "urql";
-import { ICourierClientParams } from "../types";
-import { createCourierClient } from "../client";
+import { ICourierClientParams } from "./types";
+import { createCourierClient } from "./client";
 
 export interface IGetBannerParams {
   from?: number;
@@ -55,27 +55,26 @@ type GetBanners = (
   | undefined
 >;
 
-export const getBanners = (client?: Client): GetBanners => async (
-  params?: IGetBannerParams,
-  after?: string
-) => {
-  if (!client) {
-    return Promise.resolve(undefined);
-  }
+export const getBanners =
+  (client?: Client): GetBanners =>
+  async (params?: IGetBannerParams, after?: string) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
 
-  const { limit, ...restParams } = params ?? {};
-  const results = await client
-    .query(QUERY_BANNER, { after, limit, params: restParams })
-    .toPromise();
+    const { limit, ...restParams } = params ?? {};
+    const results = await client
+      .query(QUERY_BANNER, { after, limit, params: restParams })
+      .toPromise();
 
-  const banners = results?.data?.banners?.nodes;
-  const startCursor = results?.data?.banners?.pageInfo?.startCursor;
+    const banners = results?.data?.banners?.nodes;
+    const startCursor = results?.data?.banners?.pageInfo?.startCursor;
 
-  return {
-    banners,
-    startCursor,
+    return {
+      banners,
+      startCursor,
+    };
   };
-};
 
 export default (
   params: ICourierClientParams | { client: Client }

--- a/packages/client-graphql/src/brands.ts
+++ b/packages/client-graphql/src/brands.ts
@@ -1,6 +1,6 @@
-import { ICourierClientBasicParams } from "./../types";
+import { ICourierClientBasicParams } from "./types";
 import { Client } from "urql";
-import { createCourierClient } from "../client";
+import { createCourierClient } from "./client";
 
 const brandProps = `
 settings {
@@ -61,9 +61,7 @@ query GetInAppBrand {
 }
 `;
 
-type GetBrand = (
-  brandId?: string
-) => Promise<
+type GetBrand = (brandId?: string) => Promise<
   | {
       colors: any;
       inapp: any;
@@ -72,32 +70,34 @@ type GetBrand = (
   | undefined
 >;
 
-export const getBrand = (client?: Client): GetBrand => async (brandId) => {
-  if (!client) {
-    return Promise.resolve(undefined);
-  }
+export const getBrand =
+  (client?: Client): GetBrand =>
+  async (brandId) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
 
-  const results = brandId
-    ? await client
-        .query(GET_BRAND, {
-          brandId,
-        })
-        .toPromise()
-    : await client.query(GET_INAPP_BRAND).toPromise();
+    const results = brandId
+      ? await client
+          .query(GET_BRAND, {
+            brandId,
+          })
+          .toPromise()
+      : await client.query(GET_INAPP_BRAND).toPromise();
 
-  const brandProp = brandId ? "brand" : "inAppBrand";
-  const brand = results?.data?.[brandProp];
+    const brandProp = brandId ? "brand" : "inAppBrand";
+    const brand = results?.data?.[brandProp];
 
-  const colors = brand?.settings?.colors;
-  const inapp = brand?.settings?.inapp;
-  const preferenceTemplates = brand?.preferenceTemplates?.nodes;
+    const colors = brand?.settings?.colors;
+    const inapp = brand?.settings?.inapp;
+    const preferenceTemplates = brand?.preferenceTemplates?.nodes;
 
-  return {
-    colors,
-    inapp,
-    preferenceTemplates,
+    return {
+      colors,
+      inapp,
+      preferenceTemplates,
+    };
   };
-};
 
 export default (
   params: ICourierClientBasicParams | { client?: Client }

--- a/packages/client-graphql/src/client.ts
+++ b/packages/client-graphql/src/client.ts
@@ -13,7 +13,10 @@ export const createCourierClient = (
     | {
         client?: Client;
         apiUrl?: string;
-      }
+      },
+  defaults?: {
+    apiUrl?: string;
+  }
 ): Client | undefined => {
   if ("client" in params) {
     return params.client;
@@ -26,11 +29,8 @@ export const createCourierClient = (
       authorization: `Bearer ${params.authorization}`,
     } as CourierJWTHeaders;
   } else {
-    const {
-      clientKey,
-      userId,
-      userSignature,
-    } = params as ICourierClientBasicParams;
+    const { clientKey, userId, userSignature } =
+      params as ICourierClientBasicParams;
 
     headers = {
       "x-courier-client-key": clientKey,
@@ -47,9 +47,11 @@ export const createCourierClient = (
   }
 
   return createClient({
-    url: `${
-      params.apiUrl || process.env.API_URL || `https://api.courier.com`
-    }/client/q`,
+    url:
+      defaults?.apiUrl ||
+      `${
+        params.apiUrl || process.env.API_URL || `https://api.courier.com`
+      }/client/q`,
     requestPolicy: "network-only",
     fetchOptions: () => {
       return {

--- a/packages/client-graphql/src/events.ts
+++ b/packages/client-graphql/src/events.ts
@@ -1,6 +1,6 @@
 import { Client } from "urql";
-import { ICourierClientBasicParams } from "../types";
-import { createCourierClient } from "../client";
+import { ICourierClientBasicParams } from "./types";
+import { createCourierClient } from "./client";
 
 const TRACK_EVENT = `
   mutation TrackEvent($trackingId: String!) {
@@ -10,19 +10,19 @@ const TRACK_EVENT = `
   }
 `;
 export type TrackEvent = (trackingId: string) => Promise<void>;
-export const trackEvent = (client?: Client): TrackEvent => async (
-  trackingId
-) => {
-  if (!client) {
-    return Promise.resolve(undefined);
-  }
+export const trackEvent =
+  (client?: Client): TrackEvent =>
+  async (trackingId) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
 
-  await client
-    .mutation(TRACK_EVENT, {
-      trackingId,
-    })
-    .toPromise();
-};
+    await client
+      .mutation(TRACK_EVENT, {
+        trackingId,
+      })
+      .toPromise();
+  };
 
 const TRACK_EVENT_BATCH = `
   mutation BatchTrackEvent($eventType: String!) {
@@ -32,19 +32,19 @@ const TRACK_EVENT_BATCH = `
   }
 `;
 export type TrackEventBatch = (eventType: string) => Promise<void>;
-export const trackEventBatch = (client?: Client): TrackEventBatch => async (
-  eventType
-) => {
-  if (!client) {
-    return Promise.resolve(undefined);
-  }
+export const trackEventBatch =
+  (client?: Client): TrackEventBatch =>
+  async (eventType) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
 
-  await client
-    .mutation(TRACK_EVENT_BATCH, {
-      eventType,
-    })
-    .toPromise();
-};
+    await client
+      .mutation(TRACK_EVENT_BATCH, {
+        eventType,
+      })
+      .toPromise();
+  };
 
 export default (
   params: ICourierClientBasicParams | { client?: Client }

--- a/packages/client-graphql/src/inbox/__tests__/count.spec.ts
+++ b/packages/client-graphql/src/inbox/__tests__/count.spec.ts
@@ -1,0 +1,64 @@
+global.fetch = jest.fn();
+
+const fetchMock = global.fetch as jest.Mock;
+import Inbox from "../index";
+
+describe("getInboxCount", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should work without params", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+    const inboxApi = Inbox({
+      clientKey: "CLIENT_KEY",
+      userId: "USER_ID",
+    });
+
+    await inboxApi.getInboxCount();
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"query GetInboxCount($params: FilterParamsInput) {\\\\n  count(params: $params)\\\\n}\\\\n\\",\\"operationName\\":\\"GetInboxCount\\",\\"variables\\":{}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+
+  test("should work with params", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+    const inboxApi = Inbox({
+      clientKey: "CLIENT_KEY",
+      userId: "USER_ID",
+    });
+
+    await inboxApi.getInboxCount({
+      status: "read",
+      tags: ["abc", "123"],
+    });
+
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"query GetInboxCount($params: FilterParamsInput) {\\\\n  count(params: $params)\\\\n}\\\\n\\",\\"operationName\\":\\"GetInboxCount\\",\\"variables\\":{\\"params\\":{\\"status\\":\\"read\\",\\"tags\\":[\\"abc\\",\\"123\\"]}}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+});

--- a/packages/client-graphql/src/inbox/__tests__/mark-all-read.spec.ts
+++ b/packages/client-graphql/src/inbox/__tests__/mark-all-read.spec.ts
@@ -1,0 +1,36 @@
+global.fetch = jest.fn();
+
+const fetchMock = global.fetch as jest.Mock;
+import Inbox from "../index";
+
+describe("trackEvent", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const inboxApi = Inbox({
+    clientKey: "CLIENT_KEY",
+    userId: "USER_ID",
+  });
+
+  test("markRead", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+
+    await inboxApi.markAllRead();
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"mutation TrackEvent {\\\\n  markAllRead\\\\n}\\\\n\\",\\"operationName\\":\\"TrackEvent\\",\\"variables\\":{}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+});

--- a/packages/client-graphql/src/inbox/__tests__/message.spec.ts
+++ b/packages/client-graphql/src/inbox/__tests__/message.spec.ts
@@ -1,0 +1,35 @@
+global.fetch = jest.fn();
+
+const fetchMock = global.fetch as jest.Mock;
+import Inbox from "../index";
+
+describe("getMessage", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should work without params", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+    const inboxApi = Inbox({
+      clientKey: "CLIENT_KEY",
+      userId: "USER_ID",
+    });
+
+    await inboxApi.getMessage("mockMessageId");
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"query GetInboxMessage($messageId: String!) {\\\\n  message(messageId: $messageId) {\\\\n    created\\\\n    messageId\\\\n    content {\\\\n      elemental {\\\\n        ... on TextElement {\\\\n          type\\\\n          content\\\\n          __typename\\\\n        }\\\\n        ... on ActionElement {\\\\n          type\\\\n          content\\\\n          href\\\\n          __typename\\\\n        }\\\\n        __typename\\\\n      }\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetInboxMessage\\",\\"variables\\":{\\"messageId\\":\\"mockMessageId\\"}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+});

--- a/packages/client-graphql/src/inbox/__tests__/messages.spec.ts
+++ b/packages/client-graphql/src/inbox/__tests__/messages.spec.ts
@@ -1,0 +1,64 @@
+global.fetch = jest.fn();
+
+const fetchMock = global.fetch as jest.Mock;
+import Inbox from "../index";
+
+describe("getMessages", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should work without params", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+    const inboxApi = Inbox({
+      clientKey: "CLIENT_KEY",
+      userId: "USER_ID",
+    });
+
+    await inboxApi.getMessages();
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"query GetInboxMessages($params: FilterParamsInput, $limit: Int = 10, $after: String) {\\\\n  messages(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      preview\\\\n      messageId\\\\n      read\\\\n      archived\\\\n      created\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetInboxMessages\\",\\"variables\\":{\\"params\\":{}}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+
+  test("should work with params", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+    const inboxApi = Inbox({
+      clientKey: "CLIENT_KEY",
+      userId: "USER_ID",
+    });
+
+    await inboxApi.getMessages({
+      status: "read",
+      tags: ["abc", "123"],
+    });
+
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"query GetInboxMessages($params: FilterParamsInput, $limit: Int = 10, $after: String) {\\\\n  messages(params: $params, limit: $limit, after: $after) {\\\\n    totalCount\\\\n    pageInfo {\\\\n      startCursor\\\\n      hasNextPage\\\\n      __typename\\\\n    }\\\\n    nodes {\\\\n      preview\\\\n      messageId\\\\n      read\\\\n      archived\\\\n      created\\\\n      __typename\\\\n    }\\\\n    __typename\\\\n  }\\\\n}\\\\n\\",\\"operationName\\":\\"GetInboxMessages\\",\\"variables\\":{\\"params\\":{\\"status\\":\\"read\\",\\"tags\\":[\\"abc\\",\\"123\\"]}}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+});

--- a/packages/client-graphql/src/inbox/__tests__/track-event.spec.ts
+++ b/packages/client-graphql/src/inbox/__tests__/track-event.spec.ts
@@ -1,0 +1,78 @@
+global.fetch = jest.fn();
+
+const fetchMock = global.fetch as jest.Mock;
+import Inbox from "../index";
+
+describe("trackEvent", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const inboxApi = Inbox({
+    clientKey: "CLIENT_KEY",
+    userId: "USER_ID",
+  });
+
+  test("markRead", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+
+    await inboxApi.markRead("mockMessageId");
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"mutation TrackEvent($messageId: String!) {\\\\n  read(messageId: $messageId)\\\\n}\\\\n\\",\\"operationName\\":\\"TrackEvent\\",\\"variables\\":{\\"messageId\\":\\"mockMessageId\\"}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+
+  test("markUnread", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+
+    await inboxApi.markUnread("mockMessageId");
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"mutation TrackEvent($messageId: String!) {\\\\n  unread(messageId: $messageId)\\\\n}\\\\n\\",\\"operationName\\":\\"TrackEvent\\",\\"variables\\":{\\"messageId\\":\\"mockMessageId\\"}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+
+  test("markArchive", async () => {
+    fetchMock.mockImplementation(() => Promise.resolve([]));
+
+    await inboxApi.markArchive("mockMessageId");
+    expect(fetchMock.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+        Object {
+          "body": "{\\"query\\":\\"mutation TrackEvent($messageId: String!) {\\\\n  archive(messageId: $messageId)\\\\n}\\\\n\\",\\"operationName\\":\\"TrackEvent\\",\\"variables\\":{\\"messageId\\":\\"mockMessageId\\"}}",
+          "headers": Object {
+            "content-type": "application/json",
+            "x-courier-client-key": "CLIENT_KEY",
+            "x-courier-user-id": "USER_ID",
+          },
+          "method": "POST",
+          "signal": AbortSignal {},
+        },
+      ]
+    `);
+  });
+});

--- a/packages/client-graphql/src/inbox/count.ts
+++ b/packages/client-graphql/src/inbox/count.ts
@@ -1,0 +1,27 @@
+import { Client } from "urql";
+
+export const GET_INBOX_COUNT = `
+  query GetInboxCount($params: FilterParamsInput) {
+    count(params: $params)
+  }
+`;
+
+export interface IInboxCountParams {
+  status: "read" | "unread";
+  tags: string[];
+}
+export type GetInboxCount = (params?: IInboxCountParams) => Promise<number>;
+export const getInboxCount =
+  (client?: Client): GetInboxCount =>
+  async (params) => {
+    if (!client) {
+      return Promise.resolve();
+    }
+
+    const results = await client
+      .query(GET_INBOX_COUNT, {
+        params,
+      })
+      .toPromise();
+    return results?.data?.count;
+  };

--- a/packages/client-graphql/src/inbox/index.ts
+++ b/packages/client-graphql/src/inbox/index.ts
@@ -1,0 +1,36 @@
+import { Client } from "urql";
+import { ICourierClientBasicParams } from "../types";
+import { createCourierClient } from "../client";
+
+import { GetInboxCount, getInboxCount } from "./count";
+import { GetInboxMessage, getInboxMessage } from "./message";
+import { GetInboxMessages, getInboxMessages } from "./messages";
+import { MarkAllRead, markAllRead } from "./mark-all-read";
+import { TrackEvent, trackEvent } from "./track-event";
+
+export default (
+  params: ICourierClientBasicParams | { client?: Client }
+): {
+  getInboxCount: GetInboxCount;
+  getMessage: GetInboxMessage;
+  getMessages: GetInboxMessages;
+  markAllRead: MarkAllRead;
+  markArchive: TrackEvent;
+  markRead: TrackEvent;
+  markUnread: TrackEvent;
+} => {
+  const client = createCourierClient(params, {
+    apiUrl:
+      "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+  });
+
+  return {
+    getInboxCount: getInboxCount(client),
+    getMessage: getInboxMessage(client),
+    getMessages: getInboxMessages(client),
+    markAllRead: markAllRead(client),
+    markArchive: trackEvent(client)("archive"),
+    markRead: trackEvent(client)("read"),
+    markUnread: trackEvent(client)("unread"),
+  };
+};

--- a/packages/client-graphql/src/inbox/mark-all-read.ts
+++ b/packages/client-graphql/src/inbox/mark-all-read.ts
@@ -1,0 +1,29 @@
+import { Client } from "urql";
+
+export const MARK_ALL_READ = `
+  mutation TrackEvent {
+    markAllRead
+  } 
+`;
+
+export type MarkAllRead = () => Promise<
+  | {
+      markAllRead: boolean;
+    }
+  | undefined
+>;
+
+export const markAllRead =
+  (client?: Client): MarkAllRead =>
+  async () => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
+
+    const results = await client.query(MARK_ALL_READ).toPromise();
+    const markAllRead = results?.data?.markAllRead;
+
+    return {
+      markAllRead,
+    };
+  };

--- a/packages/client-graphql/src/inbox/message.ts
+++ b/packages/client-graphql/src/inbox/message.ts
@@ -1,0 +1,48 @@
+import { Client } from "urql";
+
+export const GET_INBOX_MESSAGE = `
+  query GetInboxMessage($messageId: String!){
+    message(messageId: $messageId) {
+      created
+      messageId
+      content {
+        elemental {
+          ... on TextElement {
+            type
+            content
+          }
+          ... on ActionElement {
+            type
+            content
+            href
+          }
+        }
+      }
+    }
+  }
+`;
+
+export type GetInboxMessage = (messageId: string) => Promise<
+  | {
+      message: any;
+    }
+  | undefined
+>;
+
+export const getInboxMessage =
+  (client?: Client): GetInboxMessage =>
+  async (messageId?: string) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
+
+    const results = await client
+      .query(GET_INBOX_MESSAGE, { messageId })
+      .toPromise();
+
+    const message = results?.data?.message;
+
+    return {
+      message,
+    };
+  };

--- a/packages/client-graphql/src/inbox/messages.ts
+++ b/packages/client-graphql/src/inbox/messages.ts
@@ -1,0 +1,60 @@
+import { Client } from "urql";
+
+export interface IGetInboxMessagesParams {
+  status?: "read" | "unread";
+  limit?: number;
+  tags?: string[];
+}
+
+export const GET_INBOX_MESSAGES = `
+  query GetInboxMessages($params: FilterParamsInput, $limit: Int = 10, $after: String){
+    messages(params: $params, limit: $limit, after: $after) {
+      totalCount
+      pageInfo {
+        startCursor
+        hasNextPage
+      }
+      nodes {
+        preview
+        messageId
+        read
+        archived
+        created
+      }
+    }
+  }
+`;
+
+export type GetInboxMessages = (
+  params?: IGetInboxMessagesParams,
+  after?: string
+) => Promise<
+  | {
+      appendMessages: boolean;
+      startCursor: string;
+      messages: any[];
+    }
+  | undefined
+>;
+
+export const getInboxMessages =
+  (client?: Client): GetInboxMessages =>
+  async (params?: IGetInboxMessagesParams, after?: string) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
+
+    const { limit, ...restParams } = params ?? {};
+    const results = await client
+      .query(GET_INBOX_MESSAGES, { after, limit, params: restParams })
+      .toPromise();
+
+    const messages = results?.data?.messages?.nodes;
+    const startCursor = results?.data?.messages?.pageInfo?.startCursor;
+
+    return {
+      appendMessages: Boolean(after),
+      messages,
+      startCursor,
+    };
+  };

--- a/packages/client-graphql/src/inbox/track-event.ts
+++ b/packages/client-graphql/src/inbox/track-event.ts
@@ -1,0 +1,34 @@
+import { Client } from "urql";
+
+type EventType = "read" | "unread" | "archive";
+export const getTrackEventQuery = (eventType: EventType) => `
+  mutation TrackEvent(
+    $messageId: String!
+  ) {
+    ${eventType}(messageId: $messageId)
+  }
+`;
+
+export type TrackEvent = (messageId: string) => Promise<
+  | {
+      [eventType: string]: boolean;
+    }
+  | undefined
+>;
+
+export const trackEvent =
+  (client?: Client) =>
+  (eventType: EventType): TrackEvent =>
+  async (messageId: string) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
+
+    const QUERY = getTrackEventQuery(eventType);
+    const results = await client.query(QUERY, { messageId }).toPromise();
+    const status = results?.data?.[eventType];
+
+    return {
+      [eventType]: status,
+    };
+  };

--- a/packages/client-graphql/src/index.ts
+++ b/packages/client-graphql/src/index.ts
@@ -1,6 +1,7 @@
-export { default as Brands } from "./brands";
-export { default as Banner } from "./banner";
-export { default as Messages } from "./messages";
-export { default as Events } from "./events";
-export { default as Preferences } from "./preferences";
 export { createCourierClient } from "./client";
+export { default as Banner } from "./banner";
+export { default as Brands } from "./brands";
+export { default as Events } from "./events";
+export { default as Inbox } from "./inbox";
+export { default as Messages } from "./messages";
+export { default as Preferences } from "./preferences";

--- a/packages/client-graphql/src/messages.ts
+++ b/packages/client-graphql/src/messages.ts
@@ -1,6 +1,6 @@
 import { Client } from "urql";
-import { ICourierClientBasicParams } from "../types";
-import { createCourierClient } from "../client";
+import { ICourierClientBasicParams } from "./types";
+import { createCourierClient } from "./client";
 
 export const GET_MESSAGE_COUNT = `
   query MessageCount($params: FilterParamsInput) {

--- a/packages/client-graphql/src/messages/index.ts
+++ b/packages/client-graphql/src/messages/index.ts
@@ -14,20 +14,20 @@ export interface IMessageCountParams {
   isRead?: boolean;
 }
 type GetMessageCount = (params?: IMessageCountParams) => Promise<number>;
-export const getMessageCount = (client?: Client): GetMessageCount => async (
-  params
-) => {
-  if (!client) {
-    return Promise.resolve();
-  }
+export const getMessageCount =
+  (client?: Client): GetMessageCount =>
+  async (params) => {
+    if (!client) {
+      return Promise.resolve();
+    }
 
-  const results = await client
-    .query(GET_MESSAGE_COUNT, {
-      params,
-    })
-    .toPromise();
-  return results?.data?.messageCount;
-};
+    const results = await client
+      .query(GET_MESSAGE_COUNT, {
+        params,
+      })
+      .toPromise();
+    return results?.data?.messageCount;
+  };
 
 export interface IGetMessagesParams {
   from?: number;
@@ -90,28 +90,27 @@ type GetMessages = (
   | undefined
 >;
 
-export const getMessages = (client?: Client): GetMessages => async (
-  params?: IGetMessagesParams,
-  after?: string
-) => {
-  if (!client) {
-    return Promise.resolve(undefined);
-  }
+export const getMessages =
+  (client?: Client): GetMessages =>
+  async (params?: IGetMessagesParams, after?: string) => {
+    if (!client) {
+      return Promise.resolve(undefined);
+    }
 
-  const { limit, ...restParams } = params ?? {};
-  const results = await client
-    .query(QUERY_MESSAGES, { after, limit, params: restParams })
-    .toPromise();
+    const { limit, ...restParams } = params ?? {};
+    const results = await client
+      .query(QUERY_MESSAGES, { after, limit, params: restParams })
+      .toPromise();
 
-  const messages = results?.data?.messages?.nodes;
-  const startCursor = results?.data?.messages?.pageInfo?.startCursor;
+    const messages = results?.data?.messages?.nodes;
+    const startCursor = results?.data?.messages?.pageInfo?.startCursor;
 
-  return {
-    appendMessages: Boolean(after),
-    messages,
-    startCursor,
+    return {
+      appendMessages: Boolean(after),
+      messages,
+      startCursor,
+    };
   };
-};
 
 export default (
   params: ICourierClientBasicParams | { client?: Client }

--- a/packages/client-graphql/src/preferences.ts
+++ b/packages/client-graphql/src/preferences.ts
@@ -1,6 +1,6 @@
 import { Client } from "urql";
-import { ICourierClientBasicParams } from "../types";
-import { createCourierClient } from "../client";
+import { ICourierClientBasicParams } from "./types";
+import { createCourierClient } from "./client";
 
 const RECIPIENT_PREFERENCES = `
   query GetRecipientPreferences {
@@ -16,16 +16,16 @@ const RECIPIENT_PREFERENCES = `
 `;
 
 type GetRecipientPreferences = () => Promise<any>;
-export const getRecipientPreferences = (
-  client: Client | undefined
-): GetRecipientPreferences => async () => {
-  if (!client) {
-    return;
-  }
+export const getRecipientPreferences =
+  (client: Client | undefined): GetRecipientPreferences =>
+  async () => {
+    if (!client) {
+      return;
+    }
 
-  const results = await client.query(RECIPIENT_PREFERENCES).toPromise();
-  return results.data?.recipientPreferences.nodes;
-};
+    const results = await client.query(RECIPIENT_PREFERENCES).toPromise();
+    return results.data?.recipientPreferences.nodes;
+  };
 
 const UPDATE_RECIPIENT_PREFERENCES = `
   mutation UpdateRecipientPreferences($id: String!, $preferences: PreferencesInput!) {
@@ -39,26 +39,26 @@ type UpdateRecipientPreferences = (payload: {
   hasCustomRouting: boolean;
   routingPreferences: Array<string>;
 }) => Promise<any>;
-export const updateRecipientPreferences = (
-  client: Client | undefined
-): UpdateRecipientPreferences => async (payload) => {
-  if (!client) {
-    return Promise.resolve();
-  }
+export const updateRecipientPreferences =
+  (client: Client | undefined): UpdateRecipientPreferences =>
+  async (payload) => {
+    if (!client) {
+      return Promise.resolve();
+    }
 
-  await client
-    .mutation(UPDATE_RECIPIENT_PREFERENCES, {
-      id: payload.templateId,
-      preferences: {
-        status: payload.status,
-        hasCustomRouting: payload.hasCustomRouting,
-        routingPreferences: payload.routingPreferences,
-      },
-    })
-    .toPromise();
+    await client
+      .mutation(UPDATE_RECIPIENT_PREFERENCES, {
+        id: payload.templateId,
+        preferences: {
+          status: payload.status,
+          hasCustomRouting: payload.hasCustomRouting,
+          routingPreferences: payload.routingPreferences,
+        },
+      })
+      .toPromise();
 
-  return payload;
-};
+    return payload;
+  };
 
 export default (
   params: ICourierClientBasicParams | { client?: Client }

--- a/packages/react-hooks/src/inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/use-inbox-actions.ts
@@ -10,7 +10,7 @@ import {
 import {
   IGetMessagesParams,
   IMessageCountParams,
-} from "@trycourier/client-graphql/typings/messages";
+} from "@trycourier/client-graphql/typings/messages/messages";
 
 export interface IFetchMessagesParams {
   params?: IGetMessagesParams;
@@ -31,14 +31,8 @@ interface IInboxActions {
 }
 
 const useInboxActions = (): IInboxActions => {
-  const {
-    apiUrl,
-    clientKey,
-    dispatch,
-    inbox,
-    userId,
-    userSignature,
-  } = useCourier();
+  const { apiUrl, clientKey, dispatch, inbox, userId, userSignature } =
+    useCourier();
 
   const courierClient = createCourierClient({
     apiUrl,

--- a/packages/react-hooks/src/inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/use-inbox-actions.ts
@@ -10,7 +10,7 @@ import {
 import {
   IGetMessagesParams,
   IMessageCountParams,
-} from "@trycourier/client-graphql/typings/messages/messages";
+} from "@trycourier/client-graphql/typings/messages";
 
 export interface IFetchMessagesParams {
   params?: IGetMessagesParams;


### PR DESCRIPTION
## Description

this adds new exports to client-graphql for Inbox.  currently we have Messages but Inbox is what will be used for the new inbox apis


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
