### PR TITLE
removed courier footer

### DIFF
--- a/packages/components/src/components/index.tsx
+++ b/packages/components/src/components/index.tsx
@@ -43,11 +43,6 @@ export const CourierComponents: React.FunctionComponent = () => {
     initialPreferences ?? undefined
   );
 
-  const initialFooter = querySelector(window?.document?.body, "courier-footer");
-  const [preferenceFooter, setPreferenceFooter] = useState(
-    initialFooter ?? undefined
-  );
-
   const initialPreferencePage = querySelector(
     window?.document?.body,
     "courier-preference-page"
@@ -116,9 +111,6 @@ export const CourierComponents: React.FunctionComponent = () => {
                 case "courier-preferences":
                   setPreferencesElement(element);
                   return;
-                case "courier-footer":
-                  setPreferenceFooter(element);
-                  return;
                 case "courier-preference-page":
                   setPreferencePage(element);
                   return;
@@ -137,10 +129,6 @@ export const CourierComponents: React.FunctionComponent = () => {
                   );
                   if (childPreferences) {
                     setPreferencesElement(childPreferences);
-                  }
-                  const childFooter = querySelector(element, "courier-footer");
-                  if (childFooter) {
-                    setPreferenceFooter(childFooter);
                   }
                   return;
                 }
@@ -190,13 +178,6 @@ export const CourierComponents: React.FunctionComponent = () => {
             <Preferences />
           </Suspense>,
           preferencesElement
-        )}
-      {preferenceFooter &&
-        createPortal(
-          <Suspense fallback={<div />}>
-            <Footer />
-          </Suspense>,
-          preferenceFooter
         )}
       {preferencePage &&
         createPortal(


### PR DESCRIPTION
## Description

This removes the old component `courier-footer` from @trycourier/components.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
