### PR TITLE
[C-7266] React hooks renew session function + doc updates

### DIFF
--- a/packages/react-hooks/docs/0.overview.md
+++ b/packages/react-hooks/docs/0.overview.md
@@ -25,8 +25,11 @@ const MyApp = () => {
   /**
    * Auth token for courier provider, can be a token from Courier's auth/issue-token endpoint
    * or a JWT signed with a valid courier api key. Must include scope: "user_id:<user_id_here> inbox:read:messages"
+   *
+   * For more information on the auth/issue-token endpoint, visit:
+   * https://courier.com/docs/reference/auth/intro/
    */
-  const authorization = fetchAuthToken();
+  const authorization = await fetchAuthToken();
 
   return (
     <CourierProvider authorization="abc123">
@@ -42,17 +45,28 @@ const MyInbox = () => {
     inbox.fetchMessages();
   }, []);
 
+  // Updates message.status to "read"
   const handleReadMessage = (message) => () => {
     inbox.markMessageRead(message.messageId);
   };
 
+  // Updates message.status to "unread"
   const handleUnreadMessage = (message) => () => {
     inbox.markMessageUnread(message.messageId);
   };
 
+  // Archived messages are included in inbox.fetchMessages()
   const handleArchiveMessage = (message) => () => {
     inbox.markMessageArchived(message.messageId);
   };
+
+  // If the supplied authorization token is short lived, renew the session with a fresh token
+  // proactively before the token is set to expire. Here we use 5 minutes assuming our token only
+  // lasts 10 minutes
+  setInterval(() => {
+    const authorization = await fetchAuthToken();
+    inbox.renewSession(authorization);
+  }, 300000);
 
   return (
     <>

--- a/packages/react-hooks/docs/0.overview.md
+++ b/packages/react-hooks/docs/0.overview.md
@@ -64,10 +64,13 @@ const MyInbox = () => {
   // proactively before the token is set to expire. Here we use 5 minutes assuming our token only
   // lasts 10 minutes
   useEffect(() => {
-    setInterval(() => {
+    const interval = setInterval(() => {
       const authorization = await fetchAuthToken();
       inbox.renewSession(authorization);
     }, 300000);
+
+    // Return a cleanup function to tell react how to stop renewal when the component is unmounted.
+    return () => clearInterval(interval);
   }, []);
 
   return (

--- a/packages/react-hooks/docs/0.overview.md
+++ b/packages/react-hooks/docs/0.overview.md
@@ -45,17 +45,17 @@ const MyInbox = () => {
     inbox.fetchMessages();
   }, []);
 
-  // Updates message.status to "read"
+  // Sets message.read to current date
   const handleReadMessage = (message) => () => {
     inbox.markMessageRead(message.messageId);
   };
 
-  // Updates message.status to "unread"
+  // Removes message.read
   const handleUnreadMessage = (message) => () => {
     inbox.markMessageUnread(message.messageId);
   };
 
-  // Archived messages are included in inbox.fetchMessages()
+  // Archived messages are not included in inbox.fetchMessages()
   const handleArchiveMessage = (message) => () => {
     inbox.markMessageArchived(message.messageId);
   };
@@ -63,10 +63,12 @@ const MyInbox = () => {
   // If the supplied authorization token is short lived, renew the session with a fresh token
   // proactively before the token is set to expire. Here we use 5 minutes assuming our token only
   // lasts 10 minutes
-  setInterval(() => {
-    const authorization = await fetchAuthToken();
-    inbox.renewSession(authorization);
-  }, 300000);
+  useEffect(() => {
+    setInterval(() => {
+      const authorization = await fetchAuthToken();
+      inbox.renewSession(authorization);
+    }, 300000);
+  }, []);
 
   return (
     <>

--- a/packages/react-hooks/docs/1.types.md
+++ b/packages/react-hooks/docs/1.types.md
@@ -71,15 +71,27 @@ interface IElementalInbox {
   startCursor?: string;
   unreadMessageCount?: number;
   view?: "messages" | "preferences";
+  /** Fetches messages from the server, sets inbox.messages to the received value */
   fetchMessages: (params?: IFetchMessagesParams) => void;
+  /** Returns a count of messages who's status === "unread" */
   getUnreadMessageCount: (params?: IGetInboxMessagesParams) => void;
   init: (inbox: IElementalInbox) => void;
+  /** Marks message.status = "read" for all messages in the channel */
   markAllAsRead: () => void;
+  /** Archives the supplied message, archived messages are not returned by fetchMessages */
   markMessageArchived: (messageId: string) => Promise<void>;
+  /** Sets message.status to "read */
   markMessageRead: (messageId: string) => Promise<void>;
+  /** Sets message.status = "unread */
   markMessageUnread: (messageId: string) => Promise<void>;
   setView: (view: "messages" | "preferences") => void;
   toggleInbox: (isOpen?: boolean) => void;
+  /**
+   * Allows for renewal of sessions authorized with short lived tokens.
+   * For example, if the supplied authorization token lasts 10 minutes,
+   * this function can be called with a new token every 5 minutes to ensure
+   * messages are received in real time with no interruptions.
+   */
 }
 
 interface IInboxMessage {

--- a/packages/react-hooks/docs/1.types.md
+++ b/packages/react-hooks/docs/1.types.md
@@ -86,12 +86,14 @@ interface IElementalInbox {
   markMessageUnread: (messageId: string) => Promise<void>;
   setView: (view: "messages" | "preferences") => void;
   toggleInbox: (isOpen?: boolean) => void;
+
   /**
    * Allows for renewal of sessions authorized with short lived tokens.
    * For example, if the supplied authorization token lasts 10 minutes,
    * this function can be called with a new token every 5 minutes to ensure
    * messages are received in real time with no interruptions.
    */
+  renewSession: (authorization: string) => void;
 }
 
 interface IInboxMessage {

--- a/packages/react-hooks/docs/1.types.md
+++ b/packages/react-hooks/docs/1.types.md
@@ -73,16 +73,16 @@ interface IElementalInbox {
   view?: "messages" | "preferences";
   /** Fetches messages from the server, sets inbox.messages to the received value */
   fetchMessages: (params?: IFetchMessagesParams) => void;
-  /** Returns a count of messages who's status === "unread" */
+  /** Returns a count of messages that do not have a message.read date */
   getUnreadMessageCount: (params?: IGetInboxMessagesParams) => void;
   init: (inbox: IElementalInbox) => void;
-  /** Marks message.status = "read" for all messages in the channel */
+  /** Marks all messages as read by setting message.read to the current ISO 8601 date */
   markAllAsRead: () => void;
   /** Archives the supplied message, archived messages are not returned by fetchMessages */
   markMessageArchived: (messageId: string) => Promise<void>;
-  /** Sets message.status to "read */
+  /** Sets message.read to the current ISO 8601 date  */
   markMessageRead: (messageId: string) => Promise<void>;
-  /** Sets message.status = "unread */
+  /** Removes message.read, signalling that the message is no longer read */
   markMessageUnread: (messageId: string) => Promise<void>;
   setView: (view: "messages" | "preferences") => void;
   toggleInbox: (isOpen?: boolean) => void;

--- a/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
@@ -18,16 +18,16 @@ export interface IFetchMessagesParams {
 interface IInboxActions {
   /** Fetches messages from the server, sets inbox.messages to the received value */
   fetchMessages: (params?: IFetchMessagesParams) => void;
-  /** Returns a count of messages who's status === "unread" */
+  /** Returns a count of messages that do not have a message.read date */
   getUnreadMessageCount: (params?: IGetInboxMessagesParams) => void;
   init: (inbox: IElementalInbox) => void;
-  /** Marks message.status = "read" for all messages in the channel */
+  /** Marks all messages as read by setting message.read to the current ISO 8601 date */
   markAllAsRead: () => void;
   /** Archives the supplied message, archived messages are not returned by fetchMessages */
   markMessageArchived: (messageId: string) => Promise<void>;
-  /** Sets message.status to "read */
+  /** Sets message.read to the current ISO 8601 date  */
   markMessageRead: (messageId: string) => Promise<void>;
-  /** Sets message.status = "unread */
+  /** Removes message.read, signalling that the message is no longer read */
   markMessageUnread: (messageId: string) => Promise<void>;
   setView: (view: "messages" | "preferences") => void;
   toggleInbox: (isOpen?: boolean) => void;

--- a/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
@@ -1,4 +1,4 @@
-import { useCourier } from "@trycourier/react-provider";
+import { CourierTransport, useCourier } from "@trycourier/react-provider";
 import { IElementalInbox } from "./types";
 import { createCourierClient, Inbox } from "@trycourier/client-graphql";
 import { IGetInboxMessagesParams } from "@trycourier/client-graphql";
@@ -16,15 +16,28 @@ export interface IFetchMessagesParams {
 }
 
 interface IInboxActions {
+  /** Fetches messages from the server, sets inbox.messages to the received value */
   fetchMessages: (params?: IFetchMessagesParams) => void;
+  /** Returns a count of messages who's status === "unread" */
   getUnreadMessageCount: (params?: IGetInboxMessagesParams) => void;
   init: (inbox: IElementalInbox) => void;
+  /** Marks message.status = "read" for all messages in the channel */
   markAllAsRead: () => void;
+  /** Archives the supplied message, archived messages are not returned by fetchMessages */
   markMessageArchived: (messageId: string) => Promise<void>;
+  /** Sets message.status to "read */
   markMessageRead: (messageId: string) => Promise<void>;
+  /** Sets message.status = "unread */
   markMessageUnread: (messageId: string) => Promise<void>;
   setView: (view: "messages" | "preferences") => void;
   toggleInbox: (isOpen?: boolean) => void;
+  /**
+   * Allows for renewal of sessions authorized with short lived tokens.
+   * For example, if the supplied authorization token lasts 10 minutes,
+   * this function can be called with a new token every 5 minutes to ensure
+   * messages are received in real time with no interruptions.
+   */
+  renewSession: (token: string) => void;
 }
 
 const useElementalInboxActions = (): IInboxActions => {
@@ -36,6 +49,7 @@ const useElementalInboxActions = (): IInboxActions => {
     inbox,
     userId,
     userSignature,
+    transport,
   } =
     useCourier<{
       inbox: IElementalInbox;
@@ -105,6 +119,9 @@ const useElementalInboxActions = (): IInboxActions => {
     markMessageArchived: async (messageId: string) => {
       dispatch(markMessageArchived(messageId));
       await inboxClient.markArchive(messageId);
+    },
+    renewSession: async (token: string) => {
+      await (transport as CourierTransport).renewSession(token);
     },
   };
 };

--- a/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
@@ -37,7 +37,7 @@ interface IInboxActions {
    * this function can be called with a new token every 5 minutes to ensure
    * messages are received in real time with no interruptions.
    */
-  renewSession: (token: string) => void;
+  renewSession: (authorization: string) => void;
 }
 
 const useElementalInboxActions = (): IInboxActions => {
@@ -121,7 +121,9 @@ const useElementalInboxActions = (): IInboxActions => {
       await inboxClient.markArchive(messageId);
     },
     renewSession: async (token: string) => {
-      await (transport as CourierTransport).renewSession(token);
+      if (transport instanceof CourierTransport) {
+        transport.renewSession(token);
+      }
     },
   };
 };

--- a/packages/react-provider/docs/0.props.md
+++ b/packages/react-provider/docs/0.props.md
@@ -11,7 +11,8 @@ interface ICourierProvider {
   brand?: Brand;
   brandId?: string;
 
-  onMessage?: Interceptor;
+  /** Allows the browser to modify or react to a received message before the message is displayed to the user */
+  onMessage?: (message?: ICourierMessage) => ICourierMessage | undefined;
 
   /** Set to true to disable websockets */
   disableTransport?: boolean;
@@ -28,7 +29,8 @@ interface ICourierProvider {
 
 interface WSOptions {
   url?: string;
-  onError?: ErrorEventHandler;
+  onError?: (error: { message: string; error: Error }) => void;
+  onClose?: () => void;
   connectionTimeout?: number;
 }
 

--- a/packages/react-provider/src/transports/courier/index.ts
+++ b/packages/react-provider/src/transports/courier/index.ts
@@ -57,4 +57,8 @@ export class CourierTransport extends Transport {
   unsubscribe(channel: string, event?: string): void {
     this.ws.unsubscribe(channel, event ?? "*");
   }
+
+  renewSession(token: string): void {
+    this.ws.renewSession(token);
+  }
 }

--- a/packages/react-provider/src/types.ts
+++ b/packages/react-provider/src/types.ts
@@ -7,8 +7,10 @@ export type ErrorEventHandler = (event: ErrorEvent) => void;
 export type WSOptions = {
   url?: string;
   onError?: ErrorEventHandler;
+  onClose?: () => void;
   connectionTimeout?: number;
 };
+
 export interface Brand {
   inapp?: {
     disableCourierFooter?: boolean;


### PR DESCRIPTION
## Description

Adds `renewSession` method to the elemental inbox hooks. This allows websocket connections with short lived authorization tokens to renew their sessions indefinitely.

Also includes updates and improvements to related docs.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
