### PR TITLE
make entire toast clickable

### DIFF
--- a/packages/react-inbox/src/components/Messages2.0/Message.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/Message.tsx
@@ -175,7 +175,7 @@ const MessageWrapper: React.FunctionComponent<
     if (!read && trackingIds?.clickTrackingId && trackingIds?.readTrackingId) {
       // mark message read, but don't fire the event as the backend will do it for us,
       // we just want to set the message as read here in our local state
-      markMessageRead(messageId, trackingIds?.readTrackingId);
+      markMessageRead(messageId);
     }
   };
 

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -104,18 +104,6 @@ export const CourierProvider: React.FunctionComponent<ICourierProviderProps> =
         courierTransport.intercept(onMessage);
       }
 
-      courierTransport.listen({
-        id: "deliver-tracking",
-        listener: (courierEvent) => {
-          const courierData = courierEvent?.data?.data;
-          if (!courierData?.trackingIds?.deliverTrackingId) {
-            return;
-          }
-
-          actions.createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
-        },
-      });
-
       return () => {
         courierTransport.unsubscribe(userId);
       };

--- a/packages/react-provider/src/transports/types.ts
+++ b/packages/react-provider/src/transports/types.ts
@@ -12,6 +12,7 @@ export interface IActionBlock {
 export interface ICourierMessage {
   event?: string;
   error?: string;
+  messageId?: string;
   body?: string | React.ReactElement;
   blocks?: Array<ITextBlock | IActionBlock>;
   icon?: string | false;

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -1,26 +1,24 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { toast } from "react-toastify";
-import {
-  Container,
-  Message,
-  Title,
-  TextBlock,
-  ActionBlock,
-  Dismiss,
-} from "./styled";
+import { Container, Message, Title, TextBlock, Dismiss } from "./styled";
 import { getIcon } from "./helpers";
 import { useToast } from "~/hooks";
-import { useCourier, ICourierMessage } from "@trycourier/react-provider";
+import {
+  useCourier,
+  ICourierMessage,
+  IActionBlock,
+  ITextBlock,
+} from "@trycourier/react-provider";
 import Markdown from "markdown-to-jsx";
 
 const Body: React.FunctionComponent<
   ICourierMessage & {
     onClick?: (event: React.MouseEvent) => void;
   }
-> = ({ title, body, blocks, icon, data, onClick, ...props }) => {
+> = ({ title, body, blocks, icon, data, onClick, messageId, ...props }) => {
   const { toastProps } = props as { toastProps: any };
   const [, { config }] = useToast();
-  const { brand: courierBrand } = useCourier();
+  const { brand: courierBrand, dispatch } = useCourier();
 
   const brand = props.brand ?? config?.brand ?? courierBrand;
   const { renderBlocks, openLinksInNewTab } = config;
@@ -42,57 +40,109 @@ const Body: React.FunctionComponent<
       : (icon || config?.defaultIcon) ?? brand?.inapp?.icons?.message
   );
 
+  const handleClickMessage = (event: React.MouseEvent) => {
+    event?.preventDefault();
+
+    console.log(
+      "messageId, data?.trackingIds?.readTrackingId",
+      messageId,
+      data?.trackingIds
+    );
+
+    if (
+      data?.trackingIds?.clickTrackingId &&
+      data?.trackingIds?.readTrackingId
+    ) {
+      dispatch({
+        type: "inbox/MARK_MESSAGE_READ",
+        payload: {
+          messageId,
+        },
+      });
+    }
+
+    if (onClick) {
+      onClick(event);
+    }
+  };
+
+  const blocksByType = useMemo(() => {
+    return blocks?.reduce(
+      (acc, cur) => {
+        if (cur.type === "text") {
+          acc.text.push(cur);
+        }
+
+        if (cur.type === "action") {
+          acc.action.push(cur);
+        }
+
+        return acc;
+      },
+      {
+        action: [],
+        text: [],
+      } as {
+        action: IActionBlock[];
+        text: ITextBlock[];
+      }
+    );
+  }, [blocks]);
+
+  const clickAction = useMemo(() => {
+    if (data?.clickAction) {
+      return data.clickAction;
+    }
+
+    if (!blocksByType?.action.length || blocksByType.action?.length > 1) {
+      return;
+    }
+
+    return blocksByType.action[0].url;
+  }, []);
+
+  let containerProps: {
+    href?: string;
+    onMouseDown?: (event: React.MouseEvent) => void;
+    rel?: string;
+    target?: string;
+  } = {};
+
+  if (clickAction) {
+    containerProps.href = clickAction;
+    containerProps.onMouseDown = handleClickMessage;
+
+    if (openLinksInNewTab) {
+      containerProps = {
+        ...containerProps,
+        target: "_blank",
+        rel: "noreferrer",
+      };
+    }
+  }
+
   return (
     <Container>
-      {Icon && <Icon data-testid="message-icon" />}
-      <Message data-testid="message">
-        {title && <Title data-testid="message-title">{title}</Title>}
-        {blocks?.length ? (
-          blocks?.map((block, index) => {
-            if (block.type === "text") {
-              if (renderBlocks?.text) {
-                const Block = renderBlocks?.text;
-                return <Block {...block} key={index} />;
+      <a {...containerProps}>
+        {Icon && <Icon data-testid="message-icon" />}
+        <Message data-testid="message">
+          {title && <Title data-testid="message-title">{title}</Title>}
+          {blocksByType?.text?.length ? (
+            blocksByType?.text?.map((block, index) => {
+              if (block.type === "text") {
+                if (renderBlocks?.text) {
+                  const Block = renderBlocks?.text;
+                  return <Block {...block} key={index} />;
+                }
+
+                return (
+                  <TextBlock key={index} data-testid="message-body">
+                    {block.text && <Markdown>{block.text}</Markdown>}
+                  </TextBlock>
+                );
               }
-
-              return (
-                <TextBlock key={index} data-testid="message-body">
-                  {block.text && <Markdown>{block.text}</Markdown>}
-                </TextBlock>
-              );
-            }
-
-            if (block.type === "action") {
-              if (renderBlocks?.action) {
-                const Block = renderBlocks?.action;
-                return <Block {...block} key={index} />;
-              }
-
-              let actionProps = {};
-              const openInNewTab =
-                typeof block.openInNewTab === "boolean"
-                  ? block.openInNewTab
-                  : openLinksInNewTab;
-
-              if (openInNewTab) {
-                actionProps = {
-                  ...actionProps,
-                  target: "_blank",
-                  rel: "noreferrer",
-                };
-              }
-
-              return (
-                <ActionBlock data-testid={`action-${index}`} key={index}>
-                  <a href={block.url} {...actionProps}>
-                    {block.text}
-                  </a>
-                </ActionBlock>
-              );
-            }
-          })
-        ) : (
-          <>
+            })
+          ) : (
             <TextBlock data-testid="message-body">
               {typeof body === "string" ? (
                 <Markdown>{body as string}</Markdown>
@@ -100,21 +150,9 @@ const Body: React.FunctionComponent<
                 body
               )}
             </TextBlock>
-            {data?.clickAction && (
-              <ActionBlock data-testid="action-0">
-                <a
-                  href={data?.clickAction}
-                  onClick={onClick}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  View Details
-                </a>
-              </ActionBlock>
-            )}
-          </>
-        )}
-      </Message>
+          )}
+        </Message>
+      </a>
       <Dismiss data-testid="dismiss" onClick={handleOnClickDismiss}>
         X
       </Dismiss>

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -43,12 +43,6 @@ const Body: React.FunctionComponent<
   const handleClickMessage = (event: React.MouseEvent) => {
     event?.preventDefault();
 
-    console.log(
-      "messageId, data?.trackingIds?.readTrackingId",
-      messageId,
-      data?.trackingIds
-    );
-
     if (
       data?.trackingIds?.clickTrackingId &&
       data?.trackingIds?.readTrackingId

--- a/packages/react-toast/src/components/Body/styled.ts
+++ b/packages/react-toast/src/components/Body/styled.ts
@@ -48,7 +48,10 @@ export const Dismiss = styled.button(({ theme }) =>
 );
 
 export const Container = styled.div`
-  display: flex;
+  a {
+    display: flex;
+  }
+
   padding: 0 12px;
   width: 100%;
   position: relative;

--- a/packages/react-toast/src/hooks/index.ts
+++ b/packages/react-toast/src/hooks/index.ts
@@ -4,12 +4,13 @@ import { IToastConfig } from "../types";
 import { UseToast, ToastCaller } from "./types";
 
 export const useToast: UseToast = () => {
-  const { toast, clientKey } = useCourier<{
-    toast?: {
-      toast: ToastCaller;
-      config?: IToastConfig;
-    };
-  }>();
+  const { toast, clientKey } =
+    useCourier<{
+      toast?: {
+        toast: ToastCaller;
+        config?: IToastConfig;
+      };
+    }>();
   const toastCaller = toast?.toast ? toast.toast : () => {};
   return [
     toastCaller,
@@ -25,6 +26,8 @@ export const useListenForTransportEvent = (
   transport: ICourierContext["transport"],
   handleToast
 ) => {
+  const { createTrackEvent } = useCourier();
+
   useEffect(() => {
     if (!transport) {
       return;
@@ -33,6 +36,11 @@ export const useListenForTransportEvent = (
     transport.listen({
       id: "toast-listener",
       listener: (courierEvent) => {
+        const courierData = courierEvent?.data?.data;
+        if (courierData?.trackingIds?.deliverTrackingId) {
+          createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
+        }
+
         handleToast(courierEvent?.data);
       },
     });


### PR DESCRIPTION
## Description

- we're moving away from buttons and want to support clicking on the entire message
- only fire "deliverfed" from a toast vs the provider

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
