### PR TITLE
[C-7592] Update auth token for graphQL client on renewSession

### DIFF
--- a/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
@@ -56,17 +56,21 @@ const useElementalInboxActions = (): IInboxActions => {
       inbox: IElementalInbox;
     }>();
 
-  const courierClient = createCourierClient({
-    authorization,
-    apiUrl:
-      apiUrl ??
-      "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
-    clientKey,
-    userId,
-    userSignature,
-  });
+  const initClient = (renewedAuthHeader?: string) => {
+    const courierClient = createCourierClient({
+      authorization: renewedAuthHeader ?? authorization,
+      apiUrl:
+        apiUrl ??
+        "https://fxw3r7gdm9.execute-api.us-east-1.amazonaws.com/production/q",
+      clientKey,
+      userId,
+      userSignature,
+    });
 
-  const inboxClient = Inbox({ client: courierClient });
+    return Inbox({ client: courierClient });
+  };
+
+  let inboxClient = initClient();
 
   return {
     init: (payload) => {
@@ -125,6 +129,8 @@ const useElementalInboxActions = (): IInboxActions => {
       if (transport instanceof CourierTransport) {
         transport.renewSession(token);
       }
+
+      inboxClient = initClient(token);
     },
   };
 };


### PR DESCRIPTION
## Description

Updates auth token for graphQL client in addition to transport on renew session.

Test plan:
- Make short lived token
- Call fetchMessages - ensure resolved
- Ensure new messages received automatically via transport
- renewSession with new token
- Call fetchMessages - ensure resolved
- Ensure new messages received automatically via transport

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
