### PR TITLE
Christian/c 7680 add draft mode to preference page in

### DIFF
--- a/packages/client-graphql/src/preferences.ts
+++ b/packages/client-graphql/src/preferences.ts
@@ -117,7 +117,7 @@ export const getDraftPreferencePage =
     }
 
     const results = await client.query(DRAFT_PREFERENCE_PAGE).toPromise();
-    return results.data?.preferencePage;
+    return results.data?.draftPreferencePage;
   };
 
 const UPDATE_RECIPIENT_PREFERENCES = `

--- a/packages/client-graphql/src/preferences.ts
+++ b/packages/client-graphql/src/preferences.ts
@@ -50,6 +50,41 @@ const PREFERENCE_PAGE = `
   }
 `;
 
+const DRAFT_PREFERENCE_PAGE = `
+  query {
+    draftPreferencePage {
+      showCourierFooter
+      brand {
+        settings {
+          colors {
+            primary
+          }
+        }
+        links
+        logo {
+          href
+          image
+        }
+      }
+      sections {
+        nodes {
+          name
+          sectionId
+          routingOptions
+          hasCustomRouting
+          topics {
+            nodes {
+              defaultStatus
+              templateName
+              templateId
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 type GetRecipientPreferences = () => Promise<any>;
 export const getRecipientPreferences =
   (client: Client | undefined): GetRecipientPreferences =>
@@ -71,6 +106,17 @@ export const getPreferencePage =
     }
 
     const results = await client.query(PREFERENCE_PAGE).toPromise();
+    return results.data?.preferencePage;
+  };
+
+export const getDraftPreferencePage =
+  (client: Client | undefined): GetPreferencePage =>
+  async () => {
+    if (!client) {
+      return;
+    }
+
+    const results = await client.query(DRAFT_PREFERENCE_PAGE).toPromise();
     return results.data?.preferencePage;
   };
 
@@ -115,6 +161,7 @@ export default (
 ): {
   getRecipientPreferences: GetRecipientPreferences;
   getPreferencePage: GetPreferencePage;
+  getDraftPreferencePage: GetPreferencePage;
   updateRecipientPreferences: UpdateRecipientPreferences;
 } => {
   const client = createCourierClient(params);
@@ -122,6 +169,7 @@ export default (
   return {
     getRecipientPreferences: getRecipientPreferences(client),
     getPreferencePage: getPreferencePage(client),
+    getDraftPreferencePage: getDraftPreferencePage(client),
     updateRecipientPreferences: updateRecipientPreferences(client),
   };
 };

--- a/packages/components/src/components/PreferencePage.tsx
+++ b/packages/components/src/components/PreferencePage.tsx
@@ -1,12 +1,14 @@
 import { Footer, Header, PreferenceList } from "@trycourier/react-preferences";
 import React from "react";
 
-const PreferencePage: React.FunctionComponent = () => {
+const PreferencePage: React.FunctionComponent<{ draft?: boolean }> = ({
+  draft = false,
+}) => {
   return (
     <div>
-      <Header />
-      <PreferenceList />
-      <Footer />
+      <Header draft={draft} />
+      <PreferenceList draft={draft} />
+      <Footer draft={draft} />
     </div>
   );
 };

--- a/packages/components/src/components/index.tsx
+++ b/packages/components/src/components/index.tsx
@@ -18,6 +18,8 @@ const querySelector = (element: HTMLElement, selector: string) => {
 };
 
 export const CourierComponents: React.FunctionComponent = () => {
+  const preferencePageDraftMode =
+    window.courierConfig?.preferencePageDraftMode ?? false;
   const componentConfigs = window.courierConfig?.components;
   const initialInbox = querySelector(window?.document?.body, "courier-inbox");
   const [inboxElement, setInboxElement] = useState(initialInbox ?? undefined);
@@ -182,7 +184,7 @@ export const CourierComponents: React.FunctionComponent = () => {
       {preferencePage &&
         createPortal(
           <Suspense fallback={<div />}>
-            <PreferencePage />
+            <PreferencePage draft={preferencePageDraftMode} />
           </Suspense>,
           preferencePage
         )}

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -44,6 +44,7 @@ interface ICourierConfig {
   userId?: string;
   userSignature?: string;
   wsOptions?: WSOptions;
+  preferencePageDraftMode?: boolean;
 }
 
 let hasInit = false;

--- a/packages/react-hooks/src/preferences/reducer.ts
+++ b/packages/react-hooks/src/preferences/reducer.ts
@@ -25,6 +25,11 @@ export default (state: PreferenceState = initialState, action) => {
         ...state,
         isUpdating: true,
       };
+    case "preferences/FETCH_DRAFT_PREFERENCE_PAGE/PENDING":
+      return {
+        ...state,
+        isUpdating: true,
+      };
 
     case "preferences/FETCH_RECIPIENT_PREFERENCES/DONE": {
       return {
@@ -35,6 +40,12 @@ export default (state: PreferenceState = initialState, action) => {
     }
 
     case "preferences/FETCH_PREFERENCE_PAGE/DONE":
+      return {
+        ...state,
+        isLoading: false,
+        preferencePage: action?.payload,
+      };
+    case "preferences/FETCH_DRAFT_PREFERENCE_PAGE/DONE":
       return {
         ...state,
         isLoading: false,

--- a/packages/react-hooks/src/preferences/use-preferences-actions.ts
+++ b/packages/react-hooks/src/preferences/use-preferences-actions.ts
@@ -20,9 +20,14 @@ const usePreferencesActions = () => {
         payload: () => preferences.getRecipientPreferences(),
       });
     },
-    fetchPreferencePage: () => {
+    fetchPreferencePage: (draft = false) => {
+      const dispatchType =
+        draft === true
+          ? "preferences/FETCH_DRAFT_PREFERENCE_PAGE"
+          : "preferences/FETCH_PREFERENCE_PAGE";
+
       dispatch({
-        type: "preferences/FETCH_PREFERENCE_PAGE",
+        type: dispatchType,
         payload: () => preferences.getPreferencePage(),
       });
     },

--- a/packages/react-hooks/src/preferences/use-preferences-actions.ts
+++ b/packages/react-hooks/src/preferences/use-preferences-actions.ts
@@ -21,15 +21,17 @@ const usePreferencesActions = () => {
       });
     },
     fetchPreferencePage: (draft = false) => {
-      const dispatchType =
-        draft === true
-          ? "preferences/FETCH_DRAFT_PREFERENCE_PAGE"
-          : "preferences/FETCH_PREFERENCE_PAGE";
-
-      dispatch({
-        type: dispatchType,
-        payload: () => preferences.getPreferencePage(),
-      });
+      if (draft) {
+        dispatch({
+          type: "preferences/FETCH_DRAFT_PREFERENCE_PAGE",
+          payload: () => preferences.getDraftPreferencePage(),
+        });
+      } else {
+        dispatch({
+          type: "preferences/FETCH_PREFERENCE_PAGE",
+          payload: () => preferences.getPreferencePage(),
+        });
+      }
     },
     updateRecipientPreferences: async (payload) => {
       dispatch({

--- a/packages/react-preferences/src/components/Footer.tsx
+++ b/packages/react-preferences/src/components/Footer.tsx
@@ -4,10 +4,12 @@ import { BusinessFooter } from "./BusinessFooter";
 import { FreeFooter } from "./FreeFooter";
 import styled from "styled-components";
 
-export const Footer: React.FunctionComponent = () => {
+export const Footer: React.FunctionComponent<{ draft?: boolean }> = ({
+  draft,
+}) => {
   const preferences = usePreferences();
   useEffect(() => {
-    preferences.fetchPreferencePage();
+    preferences.fetchPreferencePage(draft);
   }, []);
 
   if (preferences.isLoading || !preferences.preferencePage) {

--- a/packages/react-preferences/src/components/Header.tsx
+++ b/packages/react-preferences/src/components/Header.tsx
@@ -2,10 +2,12 @@ import { usePreferences } from "@trycourier/react-hooks";
 import React, { useEffect } from "react";
 import styled from "styled-components";
 
-export const Header: React.FunctionComponent = () => {
+export const Header: React.FunctionComponent<{ draft?: boolean }> = ({
+  draft = false,
+}) => {
   const preferences = usePreferences();
   useEffect(() => {
-    preferences.fetchPreferencePage();
+    preferences.fetchPreferencePage(draft);
   }, []);
 
   if (preferences.isLoading || !preferences.preferencePage) {

--- a/packages/react-preferences/src/components/PreferenceList.tsx
+++ b/packages/react-preferences/src/components/PreferenceList.tsx
@@ -17,13 +17,14 @@ export const StyledList = styled.div`
 export const PreferenceList: React.FunctionComponent<{
   // TODO: define Preferences theming
   theme?: ThemeProps<any>;
-}> = (props) => {
+  draft?: boolean;
+}> = ({ theme, draft }) => {
   const { brand } = useCourier();
   const preferences = usePreferences();
 
   useEffect(() => {
     preferences.fetchRecipientPreferences();
-    preferences.fetchPreferencePage();
+    preferences.fetchPreferencePage(draft);
   }, []);
 
   const renderPreferences = () => {
@@ -60,7 +61,7 @@ export const PreferenceList: React.FunctionComponent<{
     <>
       <ThemeProvider
         theme={{
-          ...props.theme,
+          ...theme,
           brand,
         }}
       >

--- a/packages/storybook/stories/inbox/examples.stories.tsx
+++ b/packages/storybook/stories/inbox/examples.stories.tsx
@@ -10,6 +10,7 @@ import {
   color,
   select,
 } from "@storybook/addon-knobs";
+import { PreferenceList } from "@trycourier/react-preferences";
 
 export default {
   title: "Inbox/Examples",
@@ -170,31 +171,10 @@ export function MultipleInbox(): React.ReactElement {
       }}
       apiUrl={API_URL}
       clientKey={CLIENT_KEY}
-      userId={USER_ID}
+      userId="christian"
     >
-      <Toast />
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <Inbox />
-        <UseInbox />
-        <CourierProvider
-          wsOptions={{
-            url: process.env.WS_URL,
-          }}
-          apiUrl={API_URL}
-          clientKey={CLIENT_KEY}
-          userId={USER_ID}
-        >
-          <Inbox
-            brand={{
-              colors: {
-                primary: "red",
-                secondary: "pink",
-                tertiary: "orange",
-              },
-            }}
-          />
-        </CourierProvider>
-      </div>
+      <h1>Test</h1>
+      <PreferenceList />
     </CourierProvider>
   );
 }

--- a/packages/storybook/stories/inbox/examples.stories.tsx
+++ b/packages/storybook/stories/inbox/examples.stories.tsx
@@ -174,7 +174,7 @@ export function MultipleInbox(): React.ReactElement {
       userId="christian"
     >
       <h1>Test</h1>
-      <PreferenceList />
+      <PreferenceList draft />
     </CourierProvider>
   );
 }

--- a/packages/storybook/stories/inbox/examples.stories.tsx
+++ b/packages/storybook/stories/inbox/examples.stories.tsx
@@ -10,7 +10,6 @@ import {
   color,
   select,
 } from "@storybook/addon-knobs";
-import { PreferenceList } from "@trycourier/react-preferences";
 
 export default {
   title: "Inbox/Examples",
@@ -171,10 +170,31 @@ export function MultipleInbox(): React.ReactElement {
       }}
       apiUrl={API_URL}
       clientKey={CLIENT_KEY}
-      userId="christian"
+      userId={USER_ID}
     >
-      <h1>Test</h1>
-      <PreferenceList draft />
+      <Toast />
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <Inbox />
+        <UseInbox />
+        <CourierProvider
+          wsOptions={{
+            url: process.env.WS_URL,
+          }}
+          apiUrl={API_URL}
+          clientKey={CLIENT_KEY}
+          userId={USER_ID}
+        >
+          <Inbox
+            brand={{
+              colors: {
+                primary: "red",
+                secondary: "pink",
+                tertiary: "orange",
+              },
+            }}
+          />
+        </CourierProvider>
+      </div>
     </CourierProvider>
   );
 }


### PR DESCRIPTION
## Description

In order for the preview preference page to be updated without publishing the page in the preference center, the preference page needs a draft mode. Draft mode enables the preference page to pull from the "drafts" of the preference page instead of the published preference page.

https://www.loom.com/share/a4e340f975db41dea0a66e0178c5ef89

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
