### PR TITLE
Riley/c 7711 keep inbox fullpage in sync accross

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,23 +63,27 @@
     "babel-plugin-root-import": "^6.6.0",
     "babel-plugin-styled-components": "^1.12.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "eslint": "^7.18.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^22.11.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.2",
+    "eslint-plugin-react": "^7.20.0",
+    "eslint": "^7.18.0",
     "fetch-mock": "^9.11.0",
     "husky": "^6.0.0",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^26.6.3",
     "jest-styled-components": "^7.0.3",
+    "jest-websocket-mock": "^2.3.0",
+    "jest": "^26.6.3",
     "lerna": "^5.4.0",
+    "msw": "^0.43.0",
+    "nx": "^14.4.2",
     "pretty-quick": "^3.1.0",
-    "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "react": "^17.0.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.17",
@@ -89,11 +93,5 @@
     "packages": [
       "packages/*"
     ]
-  },
-  "dependencies": {
-    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
-    "jest-websocket-mock": "^2.3.0",
-    "msw": "^0.43.0",
-    "nx": "^14.4.2"
   }
 }

--- a/packages/client-graphql/package.json
+++ b/packages/client-graphql/package.json
@@ -15,8 +15,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "graphql": "^15.5.0",
     "isomorphic-fetch": "^3.0.0",
+    "graphql": "^15.5.0",
     "rimraf": "^3.0.2",
     "urql": "^2.0.1"
   },

--- a/packages/react-hooks/src/inbox/use-inbox.ts
+++ b/packages/react-hooks/src/inbox/use-inbox.ts
@@ -1,4 +1,8 @@
-import { useCourier } from "@trycourier/react-provider";
+import {
+  ICourierEventMessage,
+  ICourierMessage,
+  useCourier,
+} from "@trycourier/react-provider";
 import { useEffect } from "react";
 
 import deepExtend from "deep-extend";
@@ -27,7 +31,7 @@ const useInbox = () => {
           return;
         }
 
-        actions.newMessage(courierEvent?.data);
+        actions.newMessage(courierEvent?.data as ICourierMessage);
       },
     });
 
@@ -35,7 +39,7 @@ const useInbox = () => {
       id: "event-listener",
       type: "event",
       listener: (courierEvent) => {
-        const data = courierEvent?.data;
+        const data = courierEvent?.data as ICourierEventMessage;
         if (!dispatch || !data || !data?.event || !data?.messageId) {
           return;
         }

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@trycourier/client-graphql": "^1.53.1",
     "buffer": "^6.0.3",
-    "graphql": "^15.5.0",
     "react-use": "^17.2.1",
     "reconnecting-websocket": "^4.4.0",
     "rimraf": "^3.0.2",

--- a/packages/react-provider/src/hooks/use-client-source-id.ts
+++ b/packages/react-provider/src/hooks/use-client-source-id.ts
@@ -1,0 +1,37 @@
+import useHash from "./use-hash";
+import * as uuid from "uuid";
+import { useMemo } from "react";
+
+const useClientSourceId = ({
+  clientKey,
+  userId,
+  authorization,
+  id,
+  localStorage,
+}): string => {
+  const clientSourceKey = useHash(
+    authorization ? authorization : `${clientKey}/${userId}`
+  );
+
+  return useMemo(() => {
+    if (!localStorage) {
+      return;
+    }
+
+    const clientSourceIdLSKey = `clientSourceId/${clientSourceKey}`;
+    const localStorageClientSourceId =
+      localStorage.getItem(clientSourceIdLSKey);
+
+    if (localStorageClientSourceId) {
+      return id
+        ? `${localStorageClientSourceId}/${id}`
+        : localStorageClientSourceId;
+    }
+
+    const newClientSourceId = uuid.v4();
+    localStorage.setItem(clientSourceIdLSKey, newClientSourceId);
+    return id ? `${newClientSourceId}/${id}` : newClientSourceId;
+  }, [localStorage, clientSourceKey, id]);
+};
+
+export default useClientSourceId;

--- a/packages/react-provider/src/hooks/use-client-source-id.ts
+++ b/packages/react-provider/src/hooks/use-client-source-id.ts
@@ -2,6 +2,9 @@ import useHash from "./use-hash";
 import * as uuid from "uuid";
 import { useMemo } from "react";
 
+// this hash or clientsoureid is used to help create a managealbe sized property to store information in localstorage
+// its possible we will just have the "authorization" as an identifier and that is a huge string
+
 const useClientSourceId = ({
   clientKey,
   userId,

--- a/packages/react-provider/src/hooks/use-hash.ts
+++ b/packages/react-provider/src/hooks/use-hash.ts
@@ -1,5 +1,9 @@
 import { useMemo } from "react";
 
+/**
+    A string hashing function based on Daniel J. Bernstein's popular 'times 33' hash algorithm.
+*/
+
 function hash(text) {
   let hash = 5381;
   let index = text.length;

--- a/packages/react-provider/src/hooks/use-hash.ts
+++ b/packages/react-provider/src/hooks/use-hash.ts
@@ -1,0 +1,20 @@
+import { useMemo } from "react";
+
+function hash(text) {
+  let hash = 5381;
+  let index = text.length;
+
+  while (index) {
+    hash = (hash * 33) ^ text.charCodeAt(--index);
+  }
+
+  return hash >>> 0;
+}
+
+const useHash = (input: string) => {
+  return useMemo(() => {
+    return hash(input).toString(16);
+  }, [input]);
+};
+
+export default useHash;

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -17,7 +17,13 @@ import {
 } from "./types";
 import * as uuid from "uuid";
 import { CourierTransport } from "./transports/courier";
-import { ICourierMessage, ITextBlock, IActionBlock } from "./transports/types";
+import {
+  IActionBlock,
+  ICourierEventMessage,
+  ICourierMessage,
+  IInboxMessagePreview,
+  ITextBlock,
+} from "./transports/types";
 import reducer, { registerReducer as _registerReducer } from "./reducer";
 import defaultMiddleware, {
   registerMiddleware as _registerMiddleware,
@@ -34,13 +40,15 @@ export const registerReducer = _registerReducer;
 export const registerMiddleware = _registerMiddleware;
 
 export type {
-  Middleware,
   Brand,
   IActionBlock,
   ICourierContext,
+  ICourierEventMessage,
   ICourierMessage,
+  IInboxMessagePreview,
   IMessage,
   ITextBlock,
+  Middleware,
   WSOptions,
 };
 
@@ -67,19 +75,20 @@ export const CourierProvider: React.FunctionComponent<ICourierProviderProps> =
     wsOptions,
   }) => {
     const clientSourceId = useMemo(() => {
-      const clientKeyId = id ? `${clientKey}/${id}` : clientKey;
-      const clientSourceIdLSKey = `${clientKeyId}/${userId}/clientSourceId`;
+      const clientSourceIdLSKey = `${clientKey}/${userId}/clientSourceId`;
       const localStorageClientSourceId =
         localStorage?.getItem(clientSourceIdLSKey);
 
       if (localStorageClientSourceId) {
-        return localStorageClientSourceId;
+        return id
+          ? `${localStorageClientSourceId}/${id}`
+          : localStorageClientSourceId;
       }
 
       const newClientSourceId = uuid.v4();
       localStorage?.setItem(clientSourceIdLSKey, newClientSourceId);
-      return newClientSourceId;
-    }, [localStorage, clientKey, userId]);
+      return id ? `${newClientSourceId}/${id}` : newClientSourceId;
+    }, [localStorage, clientKey, userId, id]);
 
     const middleware = [..._middleware, ...defaultMiddleware];
 

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -5,7 +5,7 @@ if (typeof window !== "undefined") {
   window.Buffer = window.Buffer || require("buffer").Buffer;
 }
 
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect } from "react";
 import createReducer from "react-use/lib/factory/createReducer";
 
 import {
@@ -15,7 +15,6 @@ import {
   IMessage,
   WSOptions,
 } from "./types";
-import * as uuid from "uuid";
 import { CourierTransport } from "./transports/courier";
 import {
   IActionBlock,
@@ -32,6 +31,7 @@ import defaultMiddleware, {
 import useCourierActions from "./hooks/use-courier-actions";
 import { usePageVisible } from "./hooks/use-page-visible";
 import useTransport from "./hooks/use-transport";
+import useClientSourceId from "./hooks/use-client-source-id";
 
 export * from "./transports";
 export * from "./hooks";
@@ -74,24 +74,15 @@ export const CourierProvider: React.FunctionComponent<ICourierProviderProps> =
     userSignature,
     wsOptions,
   }) => {
-    const clientSourceId = useMemo(() => {
-      const clientSourceIdLSKey = `${clientKey}/${userId}/clientSourceId`;
-      const localStorageClientSourceId =
-        localStorage?.getItem(clientSourceIdLSKey);
-
-      if (localStorageClientSourceId) {
-        return id
-          ? `${localStorageClientSourceId}/${id}`
-          : localStorageClientSourceId;
-      }
-
-      const newClientSourceId = uuid.v4();
-      localStorage?.setItem(clientSourceIdLSKey, newClientSourceId);
-      return id ? `${newClientSourceId}/${id}` : newClientSourceId;
-    }, [localStorage, clientKey, userId, id]);
+    const clientSourceId = useClientSourceId({
+      authorization,
+      clientKey,
+      id,
+      localStorage,
+      userId,
+    });
 
     const middleware = [..._middleware, ...defaultMiddleware];
-
     const useReducer = useCallback(
       createReducer<any, Partial<ICourierContext>>(...middleware),
       [_middleware]

--- a/packages/react-provider/src/transports/types.ts
+++ b/packages/react-provider/src/transports/types.ts
@@ -11,7 +11,7 @@ export interface IActionBlock {
 }
 
 export interface ICourierEventMessage {
-  event?: "read" | "unread" | "archive" | "mark-all-read";
+  event: "read" | "unread" | "archive" | "mark-all-read";
   type: "event";
   messageId?: string;
   error?: string;

--- a/packages/react-provider/src/transports/types.ts
+++ b/packages/react-provider/src/transports/types.ts
@@ -9,15 +9,16 @@ export interface IActionBlock {
   url: string;
   openInNewTab?: boolean;
 }
-export interface ICourierMessage {
-  event?: string;
-  type?: "message" | "event";
-  error?: string;
+
+export interface ICourierEventMessage {
+  event?: "read" | "unread" | "archive" | "mark-all-read";
+  type: "event";
   messageId?: string;
-  body?: string;
+  error?: string;
+}
+export interface ICourierMessage {
   blocks?: Array<ITextBlock | IActionBlock>;
-  icon?: string;
-  title?: string;
+  body?: string;
   data?: {
     channel?: string;
     brandId?: string;
@@ -33,16 +34,32 @@ export interface ICourierMessage {
     trackingUrl?: string;
     clickAction?: string;
   };
+  error?: string;
+  event: string;
+  icon?: string;
+  messageId?: string;
+  title?: string;
+  type: "message";
   brand?: Brand;
+}
+
+export interface IInboxMessagePreview {
+  type: "message";
+  created?: string;
+  messageId: string;
+  preview?: string;
+  /** ISO 8601 date the message was read */
+  read?: string;
+  title?: string;
 }
 
 export interface ICourierEvent {
   type?: "message" | "event";
-  data?: ICourierMessage;
+  data?: ICourierMessage | IInboxMessagePreview | ICourierEventMessage;
 }
 
 export type ICourierEventCallback = (event: ICourierEvent) => void;
 
 export type Interceptor = (
-  message?: ICourierMessage
+  message?: ICourierMessage | ICourierEventMessage | IInboxMessagePreview
 ) => ICourierMessage | undefined;

--- a/packages/react-provider/src/ws.ts
+++ b/packages/react-provider/src/ws.ts
@@ -1,4 +1,8 @@
-import { ICourierEventCallback, ICourierMessage } from "./transports/types";
+import {
+  ICourierEventCallback,
+  ICourierEventMessage,
+  ICourierMessage,
+} from "./transports/types";
 import ReconnectingWebSocket, { ErrorEvent } from "reconnecting-websocket";
 import { ErrorEventHandler, WSOptions } from "./types";
 
@@ -127,7 +131,7 @@ export class WS {
   }
 
   private _onMessage({ data }: { data: string }): void {
-    let message: ICourierMessage;
+    let message: ICourierMessage | ICourierEventMessage;
 
     try {
       message = JSON.parse(data);

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useCallback, useMemo } from "react";
-import { toast } from "react-toastify";
+import { toast, ToastProps } from "react-toastify";
 import { Container, Message, Title, TextBlock, Dismiss } from "./styled";
 import { getIcon } from "./helpers";
 import { useToast } from "~/hooks";
@@ -13,6 +13,7 @@ import Markdown from "markdown-to-jsx";
 
 const Body: React.FunctionComponent<
   Omit<ICourierMessage, "title" | "body"> & {
+    toastProps?: ToastProps;
     onClick?: (event: React.MouseEvent) => void;
     title?: ICourierMessage["title"] | ReactElement;
     body?: ICourierMessage["body"] | ReactElement;

--- a/packages/react-toast/src/hooks/index.ts
+++ b/packages/react-toast/src/hooks/index.ts
@@ -1,4 +1,8 @@
-import { ICourierContext, useCourier } from "@trycourier/react-provider";
+import {
+  ICourierContext,
+  ICourierMessage,
+  useCourier,
+} from "@trycourier/react-provider";
 import { useEffect } from "react";
 import { IToastConfig } from "../types";
 import { UseToast, ToastCaller } from "./types";
@@ -37,7 +41,8 @@ export const useListenForTransportEvent = (
       id: "toast-listener",
       type: "message",
       listener: (courierEvent) => {
-        const courierData = courierEvent?.data?.data;
+        const courierMessage = courierEvent?.data as ICourierMessage;
+        const courierData = courierMessage?.data;
         if (courierData?.trackingIds?.deliverTrackingId) {
           createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
         }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -29,6 +29,7 @@
     "@trycourier/react-preferences": "^1.53.1",
     "@trycourier/react-provider": "^1.53.1",
     "@trycourier/react-toast": "^1.53.1",
+    "react-frame-component": "^5.2.3",
     "react-markdown": "^6.0.1",
     "storybook": "^6.5.9",
     "styled-components": "^5.2.1",

--- a/packages/storybook/stories/inbox/full-page-inbox-hooks.tsx
+++ b/packages/storybook/stories/inbox/full-page-inbox-hooks.tsx
@@ -6,9 +6,10 @@ export const FullPageInboxHooks: React.FunctionComponent = () => {
     fetchMessages,
     getUnreadMessageCount,
     isLoading,
+    markAllAsRead,
+    markMessageArchived,
     markMessageRead,
     markMessageUnread,
-    markAllAsRead,
     messages = [],
     unreadMessageCount,
   } = useElementalInbox();
@@ -47,9 +48,14 @@ export const FullPageInboxHooks: React.FunctionComponent = () => {
             <div>Title: {message?.title}</div>
             <div>Read: {message?.read}</div>
             {message?.read ? (
-              <button onClick={() => markMessageUnread(message?.messageId)}>
-                Mark as Unread
-              </button>
+              <>
+                <button onClick={() => markMessageUnread(message?.messageId)}>
+                  Mark as Unread
+                </button>
+                <button onClick={() => markMessageArchived(message?.messageId)}>
+                  Archive
+                </button>
+              </>
             ) : (
               <button onClick={() => markMessageRead(message?.messageId)}>
                 Mark as Read

--- a/packages/storybook/stories/inbox/full-page-inbox.stories.tsx
+++ b/packages/storybook/stories/inbox/full-page-inbox.stories.tsx
@@ -23,6 +23,26 @@ const FramedInBbox = () => {
 };
 
 export const Hooks = () => {
+  /*const stagingJWTCourierProps = {
+    wsOptions: {
+      url: "wss://icnrz8ttcf.execute-api.us-east-1.amazonaws.com/staging",
+    },
+    apiUrl: "https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q",
+    clientKey: "MWIxZTk1M2YtMGViYi00N2FkLWJlYWItZjU3OWJkNjA2ZWIx",
+    authorization:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InVzZXJfaWQ6c21va2V5MTIzNDUgaW5ib3g6cmVhZDptZXNzYWdlcyBpbmJveDp3cml0ZTpldmVudHMiLCJ0ZW5hbnRfc2NvcGUiOiJwdWJsaXNoZWQvcHJvZHVjdGlvbiIsInRlbmFudF9pZCI6IjFiMWU5NTNmLTBlYmItNDdhZC1iZWFiLWY1NzliZDYwNmViMSIsImlhdCI6MTY2OTY0OTA1MCwiZXhwIjoxNjY5ODIxODUwLCJqdGkiOiI2YThlZDdkNi0yMjliLTQ2MjktOWNkYy02OGZiOWM2ZGQ1ODAifQ.fYP2nB2PA4ltWukVPR0IXfgudHCTkbMXxvABiDI9TGg",
+    userId: "smokey12345",
+  };*/
+
+  /*const devCourierProops = {
+    apiUrl: "https://3rjq5oe9b1.execute-api.us-east-1.amazonaws.com/dev/q",
+    wsOptions: {
+      url: "wss://20en15n3ng.execute-api.us-east-1.amazonaws.com/dev",
+    },
+    clientKey: "NzY4MjUxY2YtM2ViOC00MjZhLTkyZWItZmFhMGU3Njc4NzY4",
+    userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
+  };*/
+
   const stagingCourierProps = {
     wsOptions: {
       url: "wss://icnrz8ttcf.execute-api.us-east-1.amazonaws.com/staging",
@@ -30,15 +50,6 @@ export const Hooks = () => {
     apiUrl: "https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q",
     clientKey: "YWZiZWViNGItMjAyMS00MzgwLTlkZDUtZWI0Y2MzNzEwNmMw",
     userId: "riley",
-  };
-
-  const devCourierProops = {
-    apiUrl: "https://3rjq5oe9b1.execute-api.us-east-1.amazonaws.com/dev/q",
-    wsOptions: {
-      url: "wss://20en15n3ng.execute-api.us-east-1.amazonaws.com/dev",
-    },
-    clientKey: "NzY4MjUxY2YtM2ViOC00MjZhLTkyZWItZmFhMGU3Njc4NzY4",
-    userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
   };
   return (
     <>
@@ -54,11 +65,11 @@ export const Hooks = () => {
           <ReactMarkdown>{`## Example`}</ReactMarkdown>
           <ReactMarkdown>{`\`\`\`javascript\n${fullPageInboxHooksString}\n\`\`\``}</ReactMarkdown>
         </div>
-        <CourierProvider {...devCourierProops}>
+        <CourierProvider {...stagingCourierProps}>
           <FullPageInboxHooks />
         </CourierProvider>
         <Frame>
-          <CourierProvider id="iframe" {...devCourierProops}>
+          <CourierProvider id="iframe" {...stagingCourierProps}>
             <FramedInBbox />
           </CourierProvider>
         </Frame>

--- a/packages/storybook/stories/inbox/full-page-inbox.stories.tsx
+++ b/packages/storybook/stories/inbox/full-page-inbox.stories.tsx
@@ -1,16 +1,45 @@
-import React from "react";
+import React, { useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { CourierProvider } from "@trycourier/react-provider";
 
 import fullPageInboxHooksString from "!raw-loader!./full-page-inbox-hooks.tsx";
 import { FullPageInboxHooks } from "./full-page-inbox-hooks";
+import Frame from "react-frame-component";
+import { useElementalInbox } from "@trycourier/react-hooks";
 
 export default {
   title: "Full Page Inbox",
 };
 
+const FramedInBbox = () => {
+  const { getUnreadMessageCount, unreadMessageCount } = useElementalInbox();
+
+  useEffect(() => {
+    getUnreadMessageCount();
+  }, []);
+
+  return <div>Unread: {unreadMessageCount}</div>;
+};
+
 export const Hooks = () => {
+  const stagingCourierProps = {
+    wsOptions: {
+      url: "wss://icnrz8ttcf.execute-api.us-east-1.amazonaws.com/staging",
+    },
+    apiUrl: "https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q",
+    clientKey: "YWZiZWViNGItMjAyMS00MzgwLTlkZDUtZWI0Y2MzNzEwNmMw",
+    userId: "riley",
+  };
+
+  const devCourierProops = {
+    apiUrl: "https://3rjq5oe9b1.execute-api.us-east-1.amazonaws.com/dev/q",
+    wsOptions: {
+      url: "wss://20en15n3ng.execute-api.us-east-1.amazonaws.com/dev",
+    },
+    clientKey: "NzY4MjUxY2YtM2ViOC00MjZhLTkyZWItZmFhMGU3Njc4NzY4",
+    userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
+  };
   return (
     <>
       <ReactMarkdown>{"TODO"}</ReactMarkdown>
@@ -25,18 +54,14 @@ export const Hooks = () => {
           <ReactMarkdown>{`## Example`}</ReactMarkdown>
           <ReactMarkdown>{`\`\`\`javascript\n${fullPageInboxHooksString}\n\`\`\``}</ReactMarkdown>
         </div>
-        <CourierProvider
-          wsOptions={{
-            url: "wss://icnrz8ttcf.execute-api.us-east-1.amazonaws.com/staging",
-          }}
-          apiUrl={
-            "https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q"
-          }
-          clientKey={"YWZiZWViNGItMjAyMS00MzgwLTlkZDUtZWI0Y2MzNzEwNmMw"}
-          userId={"riley"}
-        >
+        <CourierProvider {...devCourierProops}>
           <FullPageInboxHooks />
         </CourierProvider>
+        <Frame>
+          <CourierProvider id="iframe" {...devCourierProops}>
+            <FramedInBbox />
+          </CourierProvider>
+        </Frame>
       </div>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -16408,6 +16408,11 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-frame-component@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.3.tgz#2d5d1e29b23d5b915c839b44980d03bb9cafc453"
+  integrity sha512-r+h0o3r/uqOLNT724z4CRVkxQouKJvoi3OPfjqWACD30Y87rtEmeJrNZf1WYPGknn1Y8200HAjx7hY/dPUGgmA==
+
 react-input-autosize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16408,11 +16408,6 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-frame-component@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-5.2.3.tgz#2d5d1e29b23d5b915c839b44980d03bb9cafc453"
-  integrity sha512-r+h0o3r/uqOLNT724z4CRVkxQouKJvoi3OPfjqWACD30Y87rtEmeJrNZf1WYPGknn1Y8200HAjx7hY/dPUGgmA==
-
 react-input-autosize@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"


### PR DESCRIPTION
## Description

- handle incoming events for "read/unread" in new inbox apis
- make sure to has the clientSourceId if authorization is passed instead of clientkey

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
