### PR TITLE
Added branded buttons

### DIFF
--- a/packages/react-preferences/src/components/PreferencePage.tsx
+++ b/packages/react-preferences/src/components/PreferencePage.tsx
@@ -98,7 +98,7 @@ export const Channel = styled.div`
   }
 
   ${Input}:checked ~ ${ChannelOption} {
-    background: #1e4637;
+    background: ${({ theme }) => theme?.primary ?? "#9121c2"};
     color: white;
     border: 0;
   }
@@ -154,7 +154,7 @@ const ChannelPreferenceStyles = styled.div`
 
     ${Input}:checked ~ div {
       border: 0;
-      background-color: #1e4637;
+      background-color: ${({ theme }) => theme?.primary ?? "#9121c2"};
       svg {
         margin-left: 5px;
       }
@@ -196,9 +196,10 @@ const ChannelPreference: React.FunctionComponent<{
   channel: ChannelClassification;
 }> = ({ handleChannelRouting, routingPreferences, channel }) => {
   const [checked, setChecked] = useState(routingPreferences.includes(channel));
+  const { preferencePage } = usePreferences();
 
   return (
-    <Channel>
+    <Channel theme={{ primary: preferencePage?.brand.settings.colors.primary }}>
       <label>
         <Input
           type="checkbox"
@@ -232,7 +233,7 @@ export const PreferenceTopic: React.FunctionComponent<{
   hasCustomRouting,
   defaultHasCustomRouting,
 }) => {
-  const { updateRecipientPreferences } = usePreferences();
+  const { preferencePage, updateRecipientPreferences } = usePreferences();
 
   //Temporary mapping until I update this in the backend
   const { defaultStatus, templateName: topicName, templateId: topicId } = topic;
@@ -305,7 +306,16 @@ export const PreferenceTopic: React.FunctionComponent<{
   return (
     <StyledItem>
       <div className="template-name">{topicName}</div>
-      <StyledToggle checked={statusToggle}>
+      <StyledToggle
+        checked={statusToggle}
+        theme={{
+          brand: {
+            colors: {
+              primary: preferencePage?.brand.settings.colors.primary,
+            },
+          },
+        }}
+      >
         <label>{getDefaultStatusText(defaultStatus)}</label>
         <Toggle
           icons={false}
@@ -315,7 +325,9 @@ export const PreferenceTopic: React.FunctionComponent<{
         />
       </StyledToggle>
       {statusToggle && defaultHasCustomRouting && (
-        <ChannelPreferenceStyles>
+        <ChannelPreferenceStyles
+          theme={{ primary: preferencePage?.brand.settings.colors.primary }}
+        >
           <label className="custmoize-delivery">
             <Input
               type="checkbox"


### PR DESCRIPTION
## Description

Hosted preference page buttons now match default brand.

![image](https://user-images.githubusercontent.com/63924603/205762620-e2e7506e-61f1-4ef7-be4c-554dba68faf1.png)

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
