### PR TITLE
memoize wsOptions, make sure renewSession updates state

### DIFF
--- a/packages/react-hooks/src/inbox/elemental-inbox/reducer.ts
+++ b/packages/react-hooks/src/inbox/elemental-inbox/reducer.ts
@@ -80,7 +80,7 @@ export default (
     case INBOX_FETCH_UNREAD_MESSAGE_COUNT_DONE: {
       return {
         ...state,
-        unreadMessageCount: action.payload.count ?? 0,
+        unreadMessageCount: action.payload?.count ?? 0,
       };
     }
 

--- a/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/elemental-inbox/use-inbox-actions.ts
@@ -163,6 +163,11 @@ const useElementalInboxActions = (): IInboxActions => {
       if (transport instanceof CourierTransport) {
         transport.renewSession(token);
       }
+      return;
+      dispatch({
+        type: "root/UPDATE_AUTH_TOKEN",
+        payload: token,
+      });
     },
     newMessage: (message) => {
       if (!message.messageId) {

--- a/packages/react-provider/src/hooks/index.ts
+++ b/packages/react-provider/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useCourier } from "./use-courier";
+export { default as useCourierActions } from "./use-courier-actions";

--- a/packages/react-provider/src/hooks/use-courier-actions.ts
+++ b/packages/react-provider/src/hooks/use-courier-actions.ts
@@ -29,6 +29,12 @@ const useCourierActions = (state, dispatch) => {
           payload,
         });
       },
+      updateAuthToken: (token: string) => {
+        dispatch({
+          type: "root/UPDATE_AUTH_TOKEN",
+          payload: token,
+        });
+      },
       initToast: (payload) => {
         dispatch({
           type: "toast/INIT",

--- a/packages/react-provider/src/hooks/use-transport.ts
+++ b/packages/react-provider/src/hooks/use-transport.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Transport, CourierTransport } from "~/transports";
+import { useWhyDidYouUpdate } from "./use-why-did-you-update";
 
 const useCourierTransport = ({
   authorization,
@@ -9,12 +10,21 @@ const useCourierTransport = ({
   userSignature,
   wsOptions,
 }): Transport => {
+  useWhyDidYouUpdate("transport", {
+    authorization,
+    clientSourceId,
+    clientKey,
+    transport,
+    userSignature,
+    wsOptions,
+  });
   return useMemo(() => {
     if (transport) {
       return transport;
     }
 
     if ((clientKey || authorization) && !transport) {
+      console.log("new transport");
       return new CourierTransport({
         authorization,
         clientSourceId,

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -5,7 +5,7 @@ if (typeof window !== "undefined") {
   window.Buffer = window.Buffer || require("buffer").Buffer;
 }
 
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import createReducer from "react-use/lib/factory/createReducer";
 
 import {
@@ -72,8 +72,18 @@ export const CourierProvider: React.FunctionComponent<ICourierProviderProps> =
     transport: _transport,
     userId,
     userSignature,
-    wsOptions,
+    wsOptions: _wsOptions = {},
   }) => {
+    const wsOptions = useMemo(
+      () => _wsOptions,
+      [
+        _wsOptions.connectionTimeout,
+        _wsOptions.onClose,
+        _wsOptions.onError,
+        _wsOptions.url,
+      ]
+    );
+
     const clientSourceId = useClientSourceId({
       authorization,
       clientKey,

--- a/packages/react-provider/src/reducer.ts
+++ b/packages/react-provider/src/reducer.ts
@@ -44,6 +44,12 @@ const rootReducer = (state: Partial<ICourierContext>, action) => {
         ...action.payload,
       };
     }
+    case "root/UPDATE_AUTH_TOKEN": {
+      return {
+        ...state,
+        authorization: action.payload,
+      };
+    }
     case "root/GET_BRAND/DONE": {
       return {
         ...state,

--- a/packages/react-provider/src/ws.ts
+++ b/packages/react-provider/src/ws.ts
@@ -165,6 +165,7 @@ export class WS {
       callback,
     });
 
+    console.log("this.connected", this.connected);
     if (this.connected) {
       this.send({
         action: "subscribe",

--- a/packages/storybook/stories/inbox/full-page-inbox-hooks.tsx
+++ b/packages/storybook/stories/inbox/full-page-inbox-hooks.tsx
@@ -1,7 +1,12 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useElementalInbox } from "@trycourier/react-hooks";
 
 export const FullPageInboxHooks: React.FunctionComponent = () => {
+  const [authorization, setAuthorization] = useState("");
+  const handeInputOnChange = (event) => {
+    setAuthorization(event.target.value);
+  };
+
   const {
     fetchMessages,
     getUnreadMessageCount,
@@ -12,11 +17,16 @@ export const FullPageInboxHooks: React.FunctionComponent = () => {
     markMessageUnread,
     messages = [],
     unreadMessageCount,
+    renewSession,
   } = useElementalInbox();
 
-  useEffect(() => {
+  function getState() {
     getUnreadMessageCount();
     fetchMessages();
+  }
+
+  useEffect(() => {
+    getState();
   }, []);
 
   return (
@@ -28,6 +38,29 @@ export const FullPageInboxHooks: React.FunctionComponent = () => {
         height: "100%",
       }}
     >
+      <input
+        type="text"
+        onChange={handeInputOnChange}
+        name="auth"
+        value={authorization}
+      />
+
+      <button
+        onClick={() => {
+          renewSession(authorization);
+        }}
+      >
+        setauth
+      </button>
+
+      <button
+        onClick={() => {
+          getState();
+        }}
+      >
+        getstate
+      </button>
+
       <h3>My Inbox</h3>
       <div>Unread Messages: {unreadMessageCount}</div>
       <button onClick={() => markAllAsRead()}>Mark All Read</button>

--- a/packages/storybook/stories/inbox/full-page-inbox.stories.tsx
+++ b/packages/storybook/stories/inbox/full-page-inbox.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { CourierProvider } from "@trycourier/react-provider";
@@ -23,6 +23,8 @@ const FramedInBbox = () => {
 };
 
 export const Hooks = () => {
+  const [renderCount, setRenderCount] = useState(0);
+
   /*const stagingJWTCourierProps = {
     wsOptions: {
       url: "wss://icnrz8ttcf.execute-api.us-east-1.amazonaws.com/staging",
@@ -34,25 +36,37 @@ export const Hooks = () => {
     userId: "smokey12345",
   };*/
 
-  /*const devCourierProops = {
+  const devCourierProops = {
     apiUrl: "https://3rjq5oe9b1.execute-api.us-east-1.amazonaws.com/dev/q",
     wsOptions: {
       url: "wss://20en15n3ng.execute-api.us-east-1.amazonaws.com/dev",
     },
     clientKey: "NzY4MjUxY2YtM2ViOC00MjZhLTkyZWItZmFhMGU3Njc4NzY4",
     userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
-  };*/
+  };
 
-  const stagingCourierProps = {
+  /*const stagingCourierProps = {
     wsOptions: {
       url: "wss://icnrz8ttcf.execute-api.us-east-1.amazonaws.com/staging",
     },
     apiUrl: "https://4rq7n8hhjd.execute-api.us-east-1.amazonaws.com/staging/q",
-    clientKey: "YWZiZWViNGItMjAyMS00MzgwLTlkZDUtZWI0Y2MzNzEwNmMw",
-    userId: "riley",
-  };
+    authorization:
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InVzZXJfaWQ6c21va2V5MTIzNDUgaW5ib3g6cmVhZDptZXNzYWdlcyBpbmJveDp3cml0ZTpldmVudHMiLCJ0ZW5hbnRfc2NvcGUiOiJwdWJsaXNoZWQvcHJvZHVjdGlvbiIsInRlbmFudF9pZCI6IjFiMWU5NTNmLTBlYmItNDdhZC1iZWFiLWY1NzliZDYwNmViMSIsImlhdCI6MTY3MDk3NTgxMiwianRpIjoiNmRiNmYyODctNGMxNi00N2ZkLTliNDctNjYxNjZhY2VkOWUyIn0.QZwqutYC6TbTafsAr4Qe0FRx4K0vhp7tzGPlC_zlkg0",
+    userId: "smokey12345",
+  };*/
+
   return (
     <>
+      {renderCount}
+
+      <button
+        onClick={() => {
+          setRenderCount(renderCount + 1);
+        }}
+      >
+        render
+      </button>
+
       <ReactMarkdown>{"TODO"}</ReactMarkdown>
       <div
         style={{
@@ -65,14 +79,14 @@ export const Hooks = () => {
           <ReactMarkdown>{`## Example`}</ReactMarkdown>
           <ReactMarkdown>{`\`\`\`javascript\n${fullPageInboxHooksString}\n\`\`\``}</ReactMarkdown>
         </div>
-        <CourierProvider {...stagingCourierProps}>
+        <CourierProvider {...devCourierProops}>
           <FullPageInboxHooks />
         </CourierProvider>
-        <Frame>
+        {/*<Frame>
           <CourierProvider id="iframe" {...stagingCourierProps}>
             <FramedInBbox />
           </CourierProvider>
-        </Frame>
+      </Frame>*/}
       </div>
     </>
   );


### PR DESCRIPTION
## Description

- if you pass wsOptions it can cause issues with rerendering so we should memoize it for the consumer
- when you call renewSession,make sure we update state so the next graphql call we make has the right key

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
