### PR TITLE
Handle Null preference page

### DIFF
--- a/packages/react-preferences/src/components/PreferencesV4.tsx
+++ b/packages/react-preferences/src/components/PreferencesV4.tsx
@@ -396,8 +396,14 @@ export const PreferencesV4: React.FC<{ draft?: boolean }> = ({ draft }) => {
     }
   }, []);
 
-  if (!preferences) {
+  if (preferences.isLoading) {
     return null;
+  }
+
+  if (!preferences.preferencePage) {
+    return (
+      <div>This page is not avaliable. Please contact your administrator.</div>
+    );
   }
 
   return (

--- a/packages/react-preferences/src/components/UnsubscribePage.tsx
+++ b/packages/react-preferences/src/components/UnsubscribePage.tsx
@@ -142,8 +142,10 @@ export const UnsubscribePage: React.FunctionComponent<{
     fetchPreferencePage();
   }, []);
 
-  if (isLoading || !preferencePage) {
-    return null;
+  if (!preferencePage) {
+    return (
+      <div>This page is not avaliable. Please contact your administrator.</div>
+    );
   }
 
   const topic = preferencePage.sections.nodes
@@ -162,6 +164,10 @@ export const UnsubscribePage: React.FunctionComponent<{
     });
     setToggle(!toggle);
   };
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <PageContainer>


### PR DESCRIPTION
## Description

This PR handles a user who has not published their preference page. An unpublished preference page prevents the unsubscribe page and the preference page from loading. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
