### PR TITLE
[C-7828] hosted page spacing and dividing lines

### DIFF
--- a/packages/react-preferences/src/components/Header.tsx
+++ b/packages/react-preferences/src/components/Header.tsx
@@ -11,6 +11,7 @@ export const Header: React.FunctionComponent<{ draft?: boolean }> = ({
   }, []);
 
   const HeaderWrapper = styled.div`
+    margin-top: 60px;
     padding-top: 16px;
     width: 100%;
   `;
@@ -60,7 +61,7 @@ export const Header: React.FunctionComponent<{ draft?: boolean }> = ({
 
   const SubHeader = styled.p`
     margin: 0;
-    padding: 0 0 16px 0;
+    padding: 16px 0;
     color: #73819b;
     font-weight: 300;
     font-size: 12px;

--- a/packages/react-preferences/src/components/PreferencesV4.tsx
+++ b/packages/react-preferences/src/components/PreferencesV4.tsx
@@ -158,6 +158,11 @@ const ChannelPreferenceStyles = styled.div`
   }
 `;
 
+const SubscriptionDivider = styled.hr`
+  width: 100%;
+  border-bottom: 1px #f5f5f5 solid;
+`;
+
 const Checkmark = () => {
   return (
     <Check viewBox="0 0 9 8" height="10px" width="10px">
@@ -369,7 +374,7 @@ export const PreferenceSections: React.FunctionComponent<{
   return (
     <>
       <SectionHeader>{section.name}</SectionHeader>
-      {memoizedTopics.map(({ topic, recipientPreference }) => (
+      {memoizedTopics.map(({ topic, recipientPreference }, index) => (
         <>
           <PreferenceTopic
             topic={topic}
@@ -379,6 +384,7 @@ export const PreferenceSections: React.FunctionComponent<{
             status={recipientPreference?.status}
             routingPreferences={recipientPreference?.routingPreferences ?? []}
           />
+          {index < memoizedTopics.length - 1 && <SubscriptionDivider />}
         </>
       ))}
     </>


### PR DESCRIPTION
## Description

Spacing fixes for hosted page, added dividing lines between subscription topics
<img width="1073" alt="Screen Shot 2023-01-19 at 2 42 28 PM" src="https://user-images.githubusercontent.com/66497400/213579391-6846385f-a525-4bbf-a4ff-e3f9883c4794.png">

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
