### PR TITLE
[C-8039] Make required topics have at least 1 channel in preferences

### DIFF
--- a/packages/react-preferences/src/components/PreferencesV4.tsx
+++ b/packages/react-preferences/src/components/PreferencesV4.tsx
@@ -322,7 +322,7 @@ export const PreferenceTopic: React.FunctionComponent<{
           onChange={handleStatusChange}
         />
       </StyledToggle>
-      {statusToggle && defaultHasCustomRouting && (
+      {statusToggle && defaultHasCustomRouting && defaultStatus !== "REQUIRED" && (
         <ChannelPreferenceStyles
           theme={{ primary: preferencePage?.brand.settings.colors.primary }}
         >


### PR DESCRIPTION
## Description

Remove the ability to change communication preferences if a topic is required
<img width="961" alt="Screen Shot 2023-01-24 at 8 15 25 PM" src="https://user-images.githubusercontent.com/66497400/214478878-7c8faab7-3957-4092-9f7d-df29ce4f7b8f.png">


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
