### PR TITLE
fix(types and markallread): fix types for preferences and fix mark al…

### DIFF
--- a/packages/react-hooks/src/inbox/__tests__/reducer.spec.ts
+++ b/packages/react-hooks/src/inbox/__tests__/reducer.spec.ts
@@ -977,7 +977,6 @@ describe("inbox reducer", () => {
         ...initialState,
         unreadMessageCount: 0,
         lastMarkedAllRead: mockDate,
-        markingAllAsRead: false,
         messages: [
           {
             ...mappedMessage,
@@ -1029,7 +1028,6 @@ describe("inbox reducer", () => {
         currentTab: unreadTab,
         unreadMessageCount: 0,
         lastMarkedAllRead: mockDate,
-        markingAllAsRead: false,
         messages: [],
         tabs: [
           {
@@ -1107,7 +1105,6 @@ describe("inbox reducer", () => {
         unreadMessageCount: 0,
         messages: readMessages,
         lastMarkedAllRead: mockDate,
-        markingAllAsRead: false,
         tabs: [
           {
             ...unreadTab,

--- a/packages/react-hooks/src/inbox/__tests__/reducer.spec.ts
+++ b/packages/react-hooks/src/inbox/__tests__/reducer.spec.ts
@@ -34,7 +34,7 @@ import {
 import { ITab } from "../types";
 import { INBOX_NEW_MESSAGE, newMessage } from "../actions/new-message";
 
-import { INBOX_MARK_ALL_READ, markAllReadDone } from "../actions/mark-all-read";
+import { INBOX_MARK_ALL_READ, markAllRead } from "../actions/mark-all-read";
 import {
   fetchMessageListsPending,
   fetchMessageListsDone,
@@ -968,9 +968,7 @@ describe("inbox reducer", () => {
           unreadMessageCount: 2,
           messages: [mappedMessage, mappedMessage2],
         },
-        markAllReadDone({
-          ids: [mappedMessage.messageId, mappedMessage2.messageId],
-        })
+        markAllRead()
       );
 
       expect(state).toEqual({
@@ -1018,9 +1016,7 @@ describe("inbox reducer", () => {
           unreadMessageCount: 2,
           messages: [mappedMessage, mappedMessage2],
         },
-        markAllReadDone({
-          ids: [mappedMessage.messageId, mappedMessage2.messageId],
-        })
+        markAllRead()
       );
 
       expect(state).toEqual({
@@ -1083,9 +1079,7 @@ describe("inbox reducer", () => {
           unreadMessageCount: 2,
           messages: [mappedMessage, mappedMessage2],
         },
-        markAllReadDone({
-          ids: [mappedMessage.messageId, mappedMessage2.messageId],
-        })
+        markAllRead()
       );
 
       const readMessages = [

--- a/packages/react-hooks/src/inbox/reducer.ts
+++ b/packages/react-hooks/src/inbox/reducer.ts
@@ -4,14 +4,7 @@ import { IInbox, ITab } from "./types";
 import { InboxInit, INBOX_INIT } from "./actions/init";
 import { InboxSetView, INBOX_SET_VIEW } from "./actions/set-view";
 import { ToggleInbox, INBOX_TOGGLE } from "./actions/toggle-inbox";
-import {
-  INBOX_MARK_ALL_READ_DONE,
-  INBOX_MARK_ALL_READ_ERROR,
-  INBOX_MARK_ALL_READ_PENDING,
-  MarkAllReadDone,
-  MarkAllReadError,
-  MarkAllReadPending,
-} from "./actions/mark-all-read";
+import { MarkAllRead, INBOX_MARK_ALL_READ } from "./actions/mark-all-read";
 import { NewMessage, INBOX_NEW_MESSAGE } from "./actions/new-message";
 import {
   RehydrateMessages,
@@ -109,9 +102,7 @@ type InboxAction =
   | FetchUnreadMessageCountDone
   | InboxInit
   | InboxSetView
-  | MarkAllReadDone
-  | MarkAllReadError
-  | MarkAllReadPending
+  | MarkAllRead
   | MarkMessageArchived
   | MarkMessageOpened
   | MarkMessageRead
@@ -565,21 +556,7 @@ export default (state: IInbox = initialState, action?: InboxAction): IInbox => {
       };
     }
 
-    case INBOX_MARK_ALL_READ_PENDING: {
-      return {
-        ...state,
-        markingAllAsRead: true,
-      };
-    }
-
-    case INBOX_MARK_ALL_READ_ERROR: {
-      return {
-        ...state,
-        markingAllAsRead: false,
-      };
-    }
-
-    case INBOX_MARK_ALL_READ_DONE: {
+    case INBOX_MARK_ALL_READ: {
       const unreadMessageCount = 0;
       const currentTab = state.currentTab;
 
@@ -607,7 +584,6 @@ export default (state: IInbox = initialState, action?: InboxAction): IInbox => {
         return {
           ...state,
           lastMarkedAllRead: new Date().getTime(),
-          markingAllAsRead: false,
           messages: [],
           tabs,
           unreadMessageCount,
@@ -644,7 +620,6 @@ export default (state: IInbox = initialState, action?: InboxAction): IInbox => {
       return {
         ...state,
         lastMarkedAllRead: new Date().getTime(),
-        markingAllAsRead: false,
         messages: newMessages,
         tabs,
         unreadMessageCount,

--- a/packages/react-hooks/src/inbox/types.ts
+++ b/packages/react-hooks/src/inbox/types.ts
@@ -20,7 +20,6 @@ export interface IInbox<T = IMessage> {
   isOpen?: boolean;
   lastMarkedAllRead?: number;
   lastMessagesFetched?: number;
-  markingAllAsRead?: boolean;
   messages?: Array<T>;
   startCursor?: string;
   tabs?: ITab[];

--- a/packages/react-hooks/src/inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/use-inbox-actions.ts
@@ -16,6 +16,7 @@ import { initInbox } from "./actions/init";
 import { toggleInbox } from "./actions/toggle-inbox";
 import { setView } from "./actions/set-view";
 import { setCurrentTab } from "./actions/set-current-tab";
+import { markAllRead } from "./actions/mark-all-read";
 import { markMessageRead } from "./actions/mark-message-read";
 import { markMessageUnread } from "./actions/mark-message-unread";
 import { markMessageArchived } from "./actions/mark-message-archived";
@@ -42,7 +43,7 @@ interface IInboxActions {
   fetchMessages: (params?: IFetchMessagesParams) => void;
   getUnreadMessageCount: (params?: IGetMessagesParams) => void;
   init: (inbox: IInbox) => void;
-  markAllAsRead: () => void;
+  markAllAsRead: (fromWS?: boolean) => void;
   markMessageArchived: (
     messageId: string,
     trackingId?: string,
@@ -247,11 +248,11 @@ const useInboxActions = (): IInboxActions => {
       });
     },
     getUnreadMessageCount: handleGetUnreadMessageCount,
-    markAllAsRead: async () => {
-      dispatch({
-        type: "inbox/MARK_ALL_READ",
-        payload: () => inboxClient.markAllRead(),
-      });
+    markAllAsRead: async (fromWS) => {
+      dispatch(markAllRead());
+      if (!fromWS) {
+        await inboxClient.markAllRead();
+      }
     },
     markMessageRead: async (messageId, _trackingId, fromWS) => {
       dispatch(markMessageRead(messageId));

--- a/packages/react-hooks/src/inbox/use-inbox.ts
+++ b/packages/react-hooks/src/inbox/use-inbox.ts
@@ -40,7 +40,15 @@ const useInbox = () => {
       type: "event",
       listener: (courierEvent) => {
         const data = courierEvent?.data as ICourierEventMessage;
-        if (!dispatch || !data || !data?.event || !data?.messageId) {
+        if (!dispatch || !data || !data?.event) {
+          return;
+        }
+
+        if (data.event === "mark-all-read") {
+          actions.markAllAsRead(true);
+        }
+
+        if (!data?.messageId) {
           return;
         }
 

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./inbox";
 export { default as usePreferences } from "./preferences/use-preferences";
+export { PreferenceSection } from "./preferences/types";

--- a/packages/react-inbox/src/components/Messages2.0/Header.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/Header.tsx
@@ -9,7 +9,6 @@ import MarkAllRead from "./actions/MarkAllRead";
 import CloseInbox from "./actions/Close";
 
 import tinycolor2 from "tinycolor2";
-import LoadingIndicator from "./LoadingIndicator";
 
 export type InboxView = "settings" | "messages";
 export interface IHeaderProps {
@@ -176,7 +175,7 @@ const Header: React.FunctionComponent<IHeaderProps> = ({
   const [showDropdown, setShowDropdown] = useState(false);
 
   const { brand } = useCourier();
-  const { view, setView, tabs, toggleInbox, markingAllAsRead } = useInbox();
+  const { view, setView, tabs, toggleInbox } = useInbox();
   const handleSetView =
     (newView: "messages" | "preferences") => (event: React.MouseEvent) => {
       event.preventDefault();
@@ -284,12 +283,7 @@ const Header: React.FunctionComponent<IHeaderProps> = ({
       )}
       <div className="actions">
         {((currentTab?.filters?.isRead === false && messages.length > 0) ||
-          tabs === undefined) &&
-          (markingAllAsRead ? (
-            <LoadingIndicator size={24} />
-          ) : (
-            <MarkAllRead onClick={markAllAsRead} />
-          ))}
+          tabs === undefined) && <MarkAllRead onClick={markAllAsRead} />}
         <CloseInbox onClick={handleCloseInbox} tooltip="Close Inbox" />
       </div>
     </Container>

--- a/packages/react-preferences/src/components/PreferencesV4.tsx
+++ b/packages/react-preferences/src/components/PreferencesV4.tsx
@@ -8,7 +8,7 @@ import {
 } from "~/types";
 import { StyledToggle } from "./StyledToggle";
 import Toggle from "react-toggle";
-import type { PreferenceSection } from "@trycourier/react-hooks/typings/preferences/types";
+import { PreferenceSection } from "@trycourier/react-hooks";
 
 export const ChannelOption = styled.div`
   display: flex;


### PR DESCRIPTION
…l as read from ws

## Description

mark all as read triggered from a different browser was broken and types from preferences were exported incorrectly

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
