### PR TITLE
Feat: [C-9211] Add digest schedules to hostedPreferences

### DIFF
--- a/packages/react-preferences/src/components/DigestSchedule.tsx
+++ b/packages/react-preferences/src/components/DigestSchedule.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+const DigestSheduleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin: 12px 0px;
+  align-items: flex-start;
+
+  .digest-details {
+    display: flex;
+    flex-direction: column;
+    margin-left: 12px;
+
+    .digest-period {
+      font-size: 14px;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      width: 100%;
+      margin-bottom: 6px;
+      font-weight: bold;
+    }
+
+    .digest-repetition {
+      font-size: 12px;
+      color: #73819b;
+    }
+  }
+`;
+
+const StyledCheckbox = styled.input<{ checkedColor: string }>`
+  height: 14px;
+  width: 14px;
+  border-radius: 50%;
+  margin-top: 4px !important;
+  accent-color: ${({ checkedColor }) => checkedColor};
+`;
+
+//TODO: Add update function once backend is setup
+const DigestSchedule: React.FunctionComponent<{
+  period: string;
+  repetition;
+  isActive: boolean;
+  checkedColor: string;
+}> = ({ period, repetition, isActive, checkedColor }) => {
+  const [isChecked, setIsChecked] = useState(isActive);
+  return (
+    <DigestSheduleContainer>
+      <StyledCheckbox
+        type="checkbox"
+        checked={isChecked}
+        checkedColor={checkedColor}
+        onClick={() => setIsChecked(!isChecked)}
+      />
+      <div className="digest-details">
+        <div className="digest-period">{period}</div>
+        <div className="digest-repetition">{repetition}</div>
+      </div>
+    </DigestSheduleContainer>
+  );
+};
+
+export default DigestSchedule;

--- a/packages/react-preferences/src/components/PreferencesV4.tsx
+++ b/packages/react-preferences/src/components/PreferencesV4.tsx
@@ -9,6 +9,7 @@ import {
 import { StyledToggle } from "./StyledToggle";
 import Toggle from "react-toggle";
 import { PreferenceSection } from "@trycourier/react-hooks";
+import DigestSchedule from "./DigestSchedule";
 
 export const ChannelOption = styled.div`
   display: flex;
@@ -60,6 +61,10 @@ const StyledItem = styled.div`
     width: 100%;
     margin-bottom: 6px;
     font-weight: bold;
+  }
+
+  .digest-schedules {
+    margin-top: 16px;
   }
 `;
 
@@ -322,6 +327,18 @@ export const PreferenceTopic: React.FunctionComponent<{
           onChange={handleStatusChange}
         />
       </StyledToggle>
+      <div className="digest-schedules">
+        {topic.digestSchedules?.map((schedule, index) => (
+          <DigestSchedule
+            period={schedule.period}
+            repetition={schedule.repetition}
+            isActive={!!index}
+            checkedColor={
+              preferencePage?.brand.settings.colors.primary ?? "#9121c2"
+            }
+          />
+        ))}
+      </div>
       {statusToggle && defaultHasCustomRouting && defaultStatus !== "REQUIRED" && (
         <ChannelPreferenceStyles
           theme={{ primary: preferencePage?.brand.settings.colors.primary }}

--- a/packages/react-preferences/src/types.ts
+++ b/packages/react-preferences/src/types.ts
@@ -30,10 +30,17 @@ export interface IPreference {
   channel_preferences?: Array<ChannelClassification>;
 }
 
+export interface DigestSchedule {
+  period: string;
+  repetition: string;
+  digestId: string;
+}
+
 export interface IPreferenceTemplate {
   templateName: string;
   templateId: string;
   defaultStatus: PreferenceStatus;
+  digestSchedules?: DigestSchedule[];
 }
 
 export interface IRecipientPreference {


### PR DESCRIPTION
## Description

Add digest schedule options to preferences hostedPage
<img width="992" alt="Screenshot 2023-04-14 at 4 57 35 PM" src="https://user-images.githubusercontent.com/66497400/232173163-77f2c761-c784-4ce1-84aa-bc24afee397b.png">

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
