### PR TITLE
feat: add 3 dot menu topdown for inbox when in mobile mode

### DIFF
--- a/packages/react-inbox/src/components/Messages2.0/Message.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/Message.tsx
@@ -230,6 +230,7 @@ const MessageWrapper: React.FunctionComponent<
     openLinksInNewTab: InboxProps["openLinksInNewTab"];
     renderPin: InboxProps["renderPin"];
     setFocusedMessageId: React.Dispatch<React.SetStateAction<string>>;
+    isMobile: boolean;
   }
 > = ({
   actions,
@@ -250,6 +251,7 @@ const MessageWrapper: React.FunctionComponent<
   setFocusedMessageId,
   title,
   trackingIds,
+  isMobile,
 }) => {
   const courier = useCourier();
   const [activeTimeout, setActiveTimeout] = useState<NodeJS.Timeout>();
@@ -455,6 +457,7 @@ const MessageWrapper: React.FunctionComponent<
         read={read}
         setAreActionsHovered={setAreActionsHovered}
         trackingIds={trackingIds}
+        isMobile={isMobile}
       />
     </PositionRelative>
   );

--- a/packages/react-inbox/src/components/Messages2.0/actions/index.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/actions/index.tsx
@@ -13,8 +13,7 @@ import styled from "styled-components";
 import { InboxProps } from "~/types";
 import { IInboxMessagePreview } from "@trycourier/react-provider";
 import { getTimeAgo, getTimeAgoShort } from "~/lib";
-import StyledTippy from "~/components/StyledTippy";
-import { TippyProps } from "@tippyjs/react";
+import StyledTippy, { NewTippyProps } from "~/components/StyledTippy";
 import { useClickOutside } from "~/hooks";
 import OptionsIcon from "~/assets/options.svg";
 import deepExtend from "deep-extend";
@@ -129,7 +128,7 @@ const MessageActions: React.FunctionComponent<{
 
   const readableTimeAgo = formatDate ? formattedTime : getTimeAgo(created);
 
-  const tippyProps: TippyProps = {
+  const tippyProps: NewTippyProps = {
     visible: visible,
     placement: "left",
     interactive: true,

--- a/packages/react-inbox/src/components/Messages2.0/index.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/index.tsx
@@ -332,6 +332,7 @@ const Messages: React.ForwardRefExoticComponent<
                     openLinksInNewTab={openLinksInNewTab}
                     renderPin={renderPin}
                     setFocusedMessageId={setFocusedMessageId}
+                    isMobile={isMobile}
                   />
                 )
               )}
@@ -356,6 +357,7 @@ const Messages: React.ForwardRefExoticComponent<
                     openLinksInNewTab={openLinksInNewTab}
                     renderPin={renderPin}
                     setFocusedMessageId={setFocusedMessageId}
+                    isMobile={isMobile}
                   />
                 )
               )}

--- a/packages/react-inbox/src/components/StyledTippy.tsx
+++ b/packages/react-inbox/src/components/StyledTippy.tsx
@@ -29,7 +29,13 @@ const Styled = styled(Tippy)(({ theme }) =>
   )
 );
 
-const StyledTippy: React.FunctionComponent<TippyProps> = (props) => {
+interface Theme {
+  theme: any;
+}
+
+export interface NewTippyProps extends Omit<TippyProps, "theme">, Theme {}
+
+const StyledTippy: React.FunctionComponent<NewTippyProps> = (props) => {
   return <Styled {...props} offset={[0, 3]} />;
 };
 

--- a/packages/react-inbox/src/components/StyledTippy.tsx
+++ b/packages/react-inbox/src/components/StyledTippy.tsx
@@ -30,7 +30,7 @@ const Styled = styled(Tippy)(({ theme }) =>
 );
 
 interface Theme {
-  theme: any;
+  theme?: any;
 }
 
 export interface NewTippyProps extends Omit<TippyProps, "theme">, Theme {}

--- a/packages/react-inbox/src/components/StyledTippy.tsx
+++ b/packages/react-inbox/src/components/StyledTippy.tsx
@@ -20,6 +20,9 @@ const Styled = styled(Tippy)(({ theme }) =>
         color: "white",
         fontWeight: 700,
         borderRadius: "4px !important",
+        "> div": {
+          width: "100%",
+        },
       },
     },
     theme.tooltip


### PR DESCRIPTION
## Description

Add 3 dot menu topdown for inbox when in mobile mode

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
