### PR TITLE
feat(move onevent): move onEvent from CourierProvider to Inbox so we …

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -51,13 +51,12 @@ Installation is simple. All you need to do is add `<courier>` components to your
 
 The supported configuration of `window.courierConfig` are:
 
-| Key        | Type                                                                                 | Description                                                                                                                    |
-| ---------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| clientKey  | `string`                                                                             | Key associated with your account. Found on https://app.courier.com/integrations/courier                                        |
-| userId     | `string`                                                                             | The current user logged into your app. Associated with Courier's `recipientId`                                                 |
-| initOnLoad | `boolean`                                                                            | If you don't want Courier to try and render the components right away, you can pass this flag to defer initialization          |
-| components | `ComponentConfig`                                                                    | Map of configuration for each component (`toast` and `inbox`) on the page                                                      |
-| onEvent    | `(params: { messageId?: string, message?: IInboxMessagePreview, event: EventType })` | Function taht will be called when any event happens. EventsType includes "read", "unread", "archive", "unpin", "mark-all-read" |
+| Key        | Type              | Description                                                                                                           |
+| ---------- | ----------------- | --------------------------------------------------------------------------------------------------------------------- |
+| clientKey  | `string`          | Key associated with your account. Found on https://app.courier.com/integrations/courier                               |
+| userId     | `string`          | The current user logged into your app. Associated with Courier's `recipientId`                                        |
+| initOnLoad | `boolean`         | If you don't want Courier to try and render the components right away, you can pass this flag to defer initialization |
+| components | `ComponentConfig` | Map of configuration for each component (`toast` and `inbox`) on the page                                             |
 
 > The components will not render unless we have both the `userId` and `clientKey`
 
@@ -221,3 +220,18 @@ You update configuration of components by using:
 `window.courier.inbox.setConfig(config: InboxConfig);`
 
 `window.courier.toast.setConfig(config: ToastConfig);`
+
+## [Listening to Events](#events)
+
+You can listen to inbox events by adding a function to window.courierConfig.components.inbox.onEvent.
+
+```typescript
+type EventType = "read" | "unread" | "archive" | "click" | "mark-all-read" | "unpin";
+interface IEventParams = {
+  message?: IInboxMessagePreview;
+  messageId?: string;
+  event: EventType;
+}
+type OnEvent = (params: IEventParams) => void;
+
+```

--- a/packages/components/__tests__/index.spec.tsx
+++ b/packages/components/__tests__/index.spec.tsx
@@ -194,6 +194,24 @@ test("will support onEvent to listen for events on the window", async (done) => 
     })
   );
 
+  act(() => {
+    (window as any).courierConfig = {
+      components: {
+        inbox: {
+          onEvent: (params) => {
+            console.log("params", params);
+            expect(params).toEqual({
+              messageId: mockGraphMessage.messageId,
+              message: mockGraphMessage,
+              event: "read",
+            });
+            done();
+          },
+        },
+      },
+    };
+  });
+
   const inbox = document.createElement("courier-inbox");
   document.body.appendChild(inbox);
 
@@ -201,14 +219,6 @@ test("will support onEvent to listen for events on the window", async (done) => 
     <CourierProvider
       clientKey="MOCK_CLIENT_KEY"
       userId="MOCK_USER_ID"
-      onEvent={(params) => {
-        expect(params).toEqual({
-          messageId: mockGraphMessage.messageId,
-          message: mockGraphMessage,
-          event: "read",
-        });
-        done();
-      }}
       wsOptions={{
         url: "ws://localhost:1234",
       }}

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -48,20 +48,31 @@
         // JWT SMOKEY
         //clientKey: "YzQzMGM3OGYtYzQ2NC00NTdjLThkM2QtNWIwYzI4OTdmYmE5",
         //userId: "smokey12345",
-        onEvent: (params) => {
-          if (
-            params.event === "read" &&
-            window.courier.inbox.pinned.find(
-              (p) => p.messageId === params.messageId
-            )
-          ) {
-            window.courier.inbox.unpinMessage(params.messageId);
-          }
-        },
 
         userId: "70f6a4f4-2907-4518-b8f3-b9cfab224764",
         components: {
           inbox: {
+            theme: {
+              message: {
+                actionElement: {
+                  "&:last-child": {
+                    backgroundColor: "purple",
+                    color: "white",
+                  },
+                },
+              },
+            },
+            onEvent: (params) => {
+              console.log("params", params);
+              if (
+                params.event === "read" &&
+                window.courier.inbox.pinned.find(
+                  (p) => p.messageId === params.messageId
+                )
+              ) {
+                window.courier.inbox.unpinMessage(params.messageId);
+              }
+            },
             views: [
               {
                 id: "messages",

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import { render } from "react-dom";
 
-import {
-  CourierProvider,
-  WSOptions,
-  OnEvent,
-  IBrand,
-} from "@trycourier/react-provider";
+import { CourierProvider, WSOptions, IBrand } from "@trycourier/react-provider";
 import { CourierComponents } from "./components";
 import { InboxProps } from "@trycourier/react-inbox";
 import { ToastProps } from "@trycourier/react-toast";
@@ -45,7 +40,6 @@ interface ICourierConfig {
   enableMutationObserver?: boolean;
   inboxApiUrl?: string;
   onRouteChange?: (route: string) => void;
-  onEvent?: OnEvent;
   components?: {
     inbox?: any;
     toast?: any;
@@ -72,7 +66,6 @@ const initCourier = async (courierConfig?: ICourierConfig) => {
     brandId,
     clientKey,
     inboxApiUrl,
-    onEvent,
     onRouteChange,
     userId,
     userSignature,
@@ -97,7 +90,6 @@ const initCourier = async (courierConfig?: ICourierConfig) => {
       brandId={brandId}
       clientKey={clientKey}
       inboxApiUrl={inboxApiUrl}
-      onEvent={onEvent}
       onRouteChange={onRouteChange}
       userId={userId}
       userSignature={userSignature}

--- a/packages/react-hooks/src/inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/use-inbox-actions.ts
@@ -56,7 +56,6 @@ const useInboxActions = (): IInboxActions => {
     dispatch,
     inbox,
     inboxApiUrl,
-    onEvent,
     userId,
     userSignature,
   } =
@@ -87,6 +86,7 @@ const useInboxActions = (): IInboxActions => {
     registerMiddleware("inbox", inboxMiddleware as Middleware);
   }, []);
 
+  const onEvent = inbox?.onEvent;
   const allMessages = [...(inbox?.messages ?? []), ...(inbox?.pinned ?? [])];
 
   const handleGetUnreadMessageCount: IInboxActions["getUnreadMessageCount"] =
@@ -177,6 +177,7 @@ const useInboxActions = (): IInboxActions => {
       if (onEvent) {
         onEvent({
           messageId,
+          message: allMessages.find((m) => m.messageId === messageId),
           event: "click",
         });
       }
@@ -204,6 +205,7 @@ const useInboxActions = (): IInboxActions => {
       if (onEvent) {
         onEvent({
           messageId,
+          message: allMessages.find((m) => m.messageId === messageId),
           event: "unread",
         });
       }
@@ -217,6 +219,7 @@ const useInboxActions = (): IInboxActions => {
       if (onEvent) {
         onEvent({
           messageId,
+          message: allMessages.find((m) => m.messageId === messageId),
           event: "opened",
         });
       }
@@ -230,6 +233,7 @@ const useInboxActions = (): IInboxActions => {
       if (onEvent) {
         onEvent({
           messageId,
+          message: allMessages.find((m) => m.messageId === messageId),
           event: "archive",
         });
       }
@@ -243,6 +247,7 @@ const useInboxActions = (): IInboxActions => {
       if (onEvent) {
         onEvent({
           messageId,
+          message: allMessages.find((m) => m.messageId === messageId),
           event: "unpin",
         });
       }

--- a/packages/react-inbox/README.md
+++ b/packages/react-inbox/README.md
@@ -610,3 +610,18 @@ New Theme Properties:
 - `theme.tooltip`: accesses background and colors of tooltips
 - `theme.menu`: clicking on the inbox title opens a dropdown menu with options to edit `preferences`
 - `theme.message.clickableContainer`: when a message has an action href, we now make the entire message clickable instead of rendering an explicit button. this theme property allows access to this component. `theme.message.container` will still apply to this component but if you want to target the clickableContainer separatly you can target `theme.message.clickableContainer` which will be an `anchor` element instead of a `div`;
+
+## [Listening to Events](#events)
+
+You can listen to inbox events by passing onEvent prop to <Inbox/>
+
+```typescript
+type EventType = "read" | "unread" | "archive" | "click" | "mark-all-read" | "unpin";
+interface IEventParams = {
+  message?: IInboxMessagePreview;
+  messageId?: string;
+  event: EventType;
+}
+type OnEvent = (params: IEventParams) => void;
+
+```

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -146,12 +146,13 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
       ...localStorageState,
       brand: props.brand,
       isOpen: props.isOpen,
+      onEvent: props.onEvent,
     });
 
     if (!props.brand || Object.entries(props.brand).length === 0) {
       courierContext.getBrand(courierContext.brandId);
     }
-  }, [localStorageState, props.brand, props.isOpen]);
+  }, [localStorageState, props.brand, props.isOpen, props.onEvent]);
 
   const handleIconEvent = useCallback(() => {
     const viewId = props?.views?.[0]?.id;

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -3,6 +3,7 @@ import {
   Brand,
   PinDetails,
   IInboxMessagePreview,
+  EventType,
 } from "@trycourier/react-provider";
 import { IGetInboxMessagesParams } from "@trycourier/client-graphql";
 
@@ -38,6 +39,11 @@ export interface InboxTheme {
   root?: CSSObject;
   unreadIndicator?: CSSObject;
 }
+export type OnEvent = (eventParams: {
+  messageId?: string;
+  message?: IInboxMessagePreview;
+  event: EventType;
+}) => void;
 export interface InboxProps {
   brand?: Brand;
   className?: string;
@@ -59,6 +65,7 @@ export interface InboxProps {
     markAsRead?: string;
     markAsUnread?: string;
   };
+  onEvent?: OnEvent;
   openLinksInNewTab?: boolean;
   placement?: TippyProps["placement"];
   showUnreadMessageCount?: boolean;

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -17,7 +17,6 @@ import {
   Brand,
   ICourierContext,
   ICourierProviderProps,
-  OnEvent,
   PinDetails,
   WSOptions,
 } from "./types";
@@ -53,7 +52,6 @@ export type {
   IInboxMessagePreview,
   ITextElemental,
   Middleware,
-  OnEvent,
   PinDetails,
   WSOptions,
 };
@@ -76,7 +74,6 @@ export const CourierProvider: React.FunctionComponent<
     ? window?.localStorage
     : undefined,
   middleware: _middleware = [],
-  onEvent,
   onMessage,
   onRouteChange,
   transport: _transport,
@@ -131,7 +128,6 @@ export const CourierProvider: React.FunctionComponent<
     inboxApiUrl,
     localStorage,
     middleware,
-    onEvent,
     onRouteChange,
     transport,
     userId,

--- a/packages/react-provider/src/types.ts
+++ b/packages/react-provider/src/types.ts
@@ -1,7 +1,6 @@
 import { CourierTransport, Transport } from "./transports";
 import { Interceptor } from "./transports/types";
 import { ErrorEvent } from "reconnecting-websocket";
-import { IInboxMessagePreview } from "@trycourier/client-graphql";
 export { IInboxMessagePreview } from "@trycourier/client-graphql";
 
 export type ErrorEventHandler = (event: ErrorEvent) => void;
@@ -65,12 +64,6 @@ export type EventType =
   | "click"
   | "unpin";
 
-export type OnEvent = (eventParams: {
-  messageId?: string;
-  message?: IInboxMessagePreview;
-  event: EventType;
-}) => void;
-
 export interface ICourierProviderProps {
   apiUrl?: string;
   authorization?: string;
@@ -81,7 +74,6 @@ export interface ICourierProviderProps {
   inboxApiUrl?: string;
   localStorage?: Storage;
   middleware?: any;
-  onEvent?: OnEvent;
   onMessage?: Interceptor;
   onRouteChange?: (route: string) => void;
   transport?: CourierTransport | Transport;


### PR DESCRIPTION
…can access hooks better

having the function on CourierProvider made it hard to use things like useInbox

## Description

[Pull Request Description Here]

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
