### PR TITLE
Feat: remove typings during clean command

### DIFF
--- a/packages/client-api/package.json
+++ b/packages/client-api/package.json
@@ -9,7 +9,7 @@
     "babel": "babel src -d dist --extensions \".ts\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "test": "jest -c jest.config.js --runInBand",
     "type-check": "tsc --noEmit",
     "types": "tsc --build"

--- a/packages/client-graphql/package.json
+++ b/packages/client-graphql/package.json
@@ -8,7 +8,7 @@
     "babel": "babel src -d dist --extensions \".ts\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "test": "jest -c jest.config.js --runInBand",
     "type-check": "tsc --noEmit",
     "types": "tsc --build"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/trycourier/courier-react"
   },
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "test": "DEBUG_PRINT_LIMIT=10000 jest -c jest.config.js --runInBand",
     "build:components": "rimraf dist && webpack -p",
     "start:components": "rimraf dist && webpack && webpack-dev-server"

--- a/packages/react-brand-designer/package.json
+++ b/packages/react-brand-designer/package.json
@@ -21,7 +21,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "types": "tsc --build"
   },

--- a/packages/react-elements/package.json
+++ b/packages/react-elements/package.json
@@ -22,7 +22,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "types": "tsc --build"

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -9,7 +9,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "types": "tsc --build"

--- a/packages/react-inbox-next/package.json
+++ b/packages/react-inbox-next/package.json
@@ -9,7 +9,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "types": "tsc --build"

--- a/packages/react-inbox/package.json
+++ b/packages/react-inbox/package.json
@@ -8,7 +8,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "types": "tsc --build"
   },

--- a/packages/react-preferences/package.json
+++ b/packages/react-preferences/package.json
@@ -7,7 +7,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "type-check": "tsc --noEmit",
     "types": "tsc --build"

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -9,7 +9,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\" --ignore \"src/**/__mocks__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "types": "tsc --build"

--- a/packages/react-toast/package.json
+++ b/packages/react-toast/package.json
@@ -14,7 +14,7 @@
     "babel": "babel src -d dist --extensions \".ts,.tsx\" --ignore \"src/**/__tests__/**\"",
     "build:watch": "yarn babel --watch",
     "build": "rimraf dist && yarn babel",
-    "clean": "rimraf dist",
+    "clean": "rimraf dist && rimraf typings",
     "type-check": "tsc --noEmit",
     "readme": "concat-md --toc --decrease-title-levels --dir-name-as-title docs > README.md",
     "types": "tsc --build"


### PR DESCRIPTION
## Description
- remove the typings folder during `yarn clean` to re-generate them correctly

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

