### PR TITLE
feat: allows filtering inbox by accountId

### DIFF
--- a/packages/client-graphql/src/inbox/messages.ts
+++ b/packages/client-graphql/src/inbox/messages.ts
@@ -2,6 +2,7 @@ import { Client } from "urql";
 import { IActionElemental } from "./message";
 
 export interface IGetInboxMessagesParams {
+  accountId?: string;
   archived?: boolean;
   from?: string | number;
   limit?: number;

--- a/packages/react-hooks/src/inbox/types.ts
+++ b/packages/react-hooks/src/inbox/types.ts
@@ -1,5 +1,10 @@
-import { Brand, IInboxMessagePreview } from "@trycourier/react-provider";
+import {
+  Brand,
+  IInboxMessagePreview,
+  OnEvent,
+} from "@trycourier/react-provider";
 export interface IInbox<T = IInboxMessagePreview> {
+  accountId?: string;
   brand?: Brand;
   from?: number;
   isLoading?: boolean;
@@ -7,6 +12,7 @@ export interface IInbox<T = IInboxMessagePreview> {
   lastMarkedAllRead?: number;
   lastMessagesFetched?: number;
   messages?: Array<T>;
+  onEvent: OnEvent;
   pinned?: Array<T>;
   startCursor?: string;
   unreadMessageCount?: number;

--- a/packages/react-hooks/src/inbox/types.ts
+++ b/packages/react-hooks/src/inbox/types.ts
@@ -12,7 +12,7 @@ export interface IInbox<T = IInboxMessagePreview> {
   lastMarkedAllRead?: number;
   lastMessagesFetched?: number;
   messages?: Array<T>;
-  onEvent: OnEvent;
+  onEvent?: OnEvent;
   pinned?: Array<T>;
   startCursor?: string;
   unreadMessageCount?: number;

--- a/packages/react-hooks/src/inbox/use-inbox.ts
+++ b/packages/react-hooks/src/inbox/use-inbox.ts
@@ -23,7 +23,7 @@ const useInbox = (): IInbox<IInboxMessagePreview> & IInboxActions => {
   }
 
   if (accountId) {
-    inbox.accountId = accountId ?? inbox.accountId;
+    inbox.accountId = accountId;
   }
 
   useEffect(() => {

--- a/packages/react-hooks/src/inbox/use-inbox.ts
+++ b/packages/react-hooks/src/inbox/use-inbox.ts
@@ -11,7 +11,7 @@ import useInboxActions, { IInboxActions } from "./use-inbox-actions";
 import { IInbox } from "./types";
 
 const useInbox = (): IInbox<IInboxMessagePreview> & IInboxActions => {
-  const { dispatch, inbox, transport, brand } =
+  const { dispatch, inbox, transport, brand, accountId } =
     useCourier<{
       inbox: IInbox;
     }>();
@@ -20,6 +20,10 @@ const useInbox = (): IInbox<IInboxMessagePreview> & IInboxActions => {
 
   if (inbox && (brand || inbox.brand)) {
     inbox.brand = deepExtend({}, brand ?? {}, inbox.brand ?? {});
+  }
+
+  if (accountId) {
+    inbox.accountId = accountId ?? inbox.accountId;
   }
 
   useEffect(() => {

--- a/packages/react-inbox/src/components/Messages2.0/index.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/index.tsx
@@ -202,6 +202,7 @@ const Messages: React.ForwardRefExoticComponent<
     const { fetchRecipientPreferences } = usePreferences();
 
     const {
+      accountId,
       brand,
       fetchMessages,
       getUnreadMessageCount,
@@ -227,9 +228,12 @@ const Messages: React.ForwardRefExoticComponent<
       }
 
       fetchMessages({
-        params: currentView?.params,
+        params: {
+          ...currentView?.params,
+          accountId,
+        },
       });
-    }, [view, currentView]);
+    }, [accountId, view, currentView]);
 
     useOnScroll(
       messageListRef,

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -41,6 +41,7 @@ export interface InboxTheme {
 }
 
 export interface InboxProps {
+  accountId?: string;
   brand?: Brand;
   className?: string;
   defaultIcon?: false | string;

--- a/packages/react-inbox/src/types.ts
+++ b/packages/react-inbox/src/types.ts
@@ -3,7 +3,7 @@ import {
   Brand,
   PinDetails,
   IInboxMessagePreview,
-  EventType,
+  OnEvent,
 } from "@trycourier/react-provider";
 import { IGetInboxMessagesParams } from "@trycourier/client-graphql";
 
@@ -39,11 +39,7 @@ export interface InboxTheme {
   root?: CSSObject;
   unreadIndicator?: CSSObject;
 }
-export type OnEvent = (eventParams: {
-  messageId?: string;
-  message?: IInboxMessagePreview;
-  event: EventType;
-}) => void;
+
 export interface InboxProps {
   brand?: Brand;
   className?: string;

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -15,10 +15,12 @@ import createReducer from "react-use/lib/factory/createReducer";
 
 import {
   Brand,
+  EventType,
   ICourierContext,
   ICourierProviderProps,
   PinDetails,
   WSOptions,
+  OnEvent,
 } from "./types";
 import { CourierTransport } from "./transports/courier";
 import {
@@ -54,6 +56,8 @@ export type {
   Middleware,
   PinDetails,
   WSOptions,
+  EventType,
+  OnEvent,
 };
 
 export const CourierContext =

--- a/packages/react-provider/src/transports/types.ts
+++ b/packages/react-provider/src/transports/types.ts
@@ -1,5 +1,5 @@
 export interface ICourierEventMessage {
-  event: "read" | "unread" | "archive" | "mark-all-read" | "opened";
+  event: "read" | "unread" | "archive" | "mark-all-read" | "opened" | "unpin";
   type: "event";
   messageId?: string;
   error?: string;

--- a/packages/react-provider/src/types.ts
+++ b/packages/react-provider/src/types.ts
@@ -1,5 +1,5 @@
 import { CourierTransport, Transport } from "./transports";
-import { Interceptor } from "./transports/types";
+import { IInboxMessagePreview, Interceptor } from "./transports/types";
 import { ErrorEvent } from "reconnecting-websocket";
 export { IInboxMessagePreview } from "@trycourier/client-graphql";
 
@@ -13,6 +13,12 @@ export type WSOptions = {
   onReconnect?: () => void;
   connectionTimeout?: number;
 };
+
+export type OnEvent = (eventParams: {
+  messageId?: string;
+  message?: IInboxMessagePreview;
+  event: EventType;
+}) => void;
 
 export interface PinDetails {
   id: string;

--- a/packages/react-provider/src/ws.ts
+++ b/packages/react-provider/src/ws.ts
@@ -14,6 +14,7 @@ export class WS {
     event?: string;
     callback: ICourierEventCallback;
   }>;
+  private accountId?: string;
   private clientSourceId?: string;
   private authorization?: string;
   private clientKey?: string;
@@ -31,18 +32,21 @@ export class WS {
   protected messageCallback;
 
   constructor({
+    accountId,
     authorization,
     clientKey,
     options,
     clientSourceId,
     userSignature,
   }: {
+    accountId?: string;
     authorization?: string;
     clientSourceId?: string;
     clientKey?: string;
     options?: WSOptions;
     userSignature?: string;
   }) {
+    this.accountId = accountId;
     this.connectionCount = 0;
     this.authorization = authorization;
     this.messageCallback = null;
@@ -173,6 +177,7 @@ export class WS {
       this.send({
         action: "subscribe",
         data: {
+          accountId: this.accountId,
           channel,
           clientKey: this.clientKey,
           clientSourceId: this.clientSourceId,


### PR DESCRIPTION
## Description

Allows specifying accountId in `courier-provider` 


```tsx
<CourierProvider
  clientKey="<your_client_key>"
  userId="<your_user_id>"
  accountId="<your_account_id>"
>
  <Inbox theme={theme} {...props} />
</CourierProvider>
```

This inbox will fetch and render all messages that were sent to user+accountId. If you don't specify accountId, your inbox will receive all messages sent to the user. 


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

