### PR TITLE
fix: check if `document` is defined in `use-page-visible` hook

### DIFF
--- a/packages/react-provider/src/hooks/use-page-visible.ts
+++ b/packages/react-provider/src/hooks/use-page-visible.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 export function getIsDocumentHidden() {
-  return !document.hidden;
+  return typeof document !== "undefined" && !document.hidden;
 }
 
 export function usePageVisible(callback: (isVisible: boolean) => void) {
@@ -10,6 +10,9 @@ export function usePageVisible(callback: (isVisible: boolean) => void) {
   };
 
   useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
     document.addEventListener("visibilitychange", onVisibilityChange, false);
 
     return () => {


### PR DESCRIPTION
## Description

👋  from hipages 😃 
React Native environments don't have the `document` global which means the provider is not really useable in RN projects. Stubbing `document` in RN projects breaks other libraries as they also check for its presence to turn on/off browser-specific features.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
