### PR TITLE
allow empty userid/clientkey if authorization provided

### DIFF
--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -104,7 +104,7 @@ const initCourier = (courierConfig?: ICourierConfig) => {
     return;
   }
 
-  if (!userId || !clientKey) {
+  if (!authorization && (!userId || !clientKey)) {
     return;
   }
   const existingCourierRoot =


### PR DESCRIPTION
## Description

Allow for empty `userId` and `clientKey` if `authorization` provided. Currently if `authorization` is used to authenticate, `clientKey` and `userID` are not needed but will prevent component rendering if empty/null.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
