### PR TITLE
fix: added missing renderActionsAsButtons to types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           node-version: "14.X"
       - run: yarn
+      - name: Typecheck
+        run: yarn types
       - name: Test
         run: yarn test
       - uses: codecov/codecov-action@v1

--- a/packages/react-provider/src/types.ts
+++ b/packages/react-provider/src/types.ts
@@ -54,6 +54,7 @@ export interface Brand {
       borderRadius?: string;
       timerAutoClose?: number;
     };
+    renderActionsAsButtons?: boolean;
   };
   colors?: {
     primary?: string;


### PR DESCRIPTION
## Description

This PR adds missing `renderActionsAsButtons` prop to `Brand.inapp` type.

I've also added `yarn types` check to the PR workflow so you can catch these errors earlier,,

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
