### PR TITLE
fix(export PreferenceSections): integrate PreferenceSections

### DIFF
--- a/packages/react-preferences/src/components/index.ts
+++ b/packages/react-preferences/src/components/index.ts
@@ -1,6 +1,6 @@
 export { UnsubscribePage } from "./UnsubscribePage";
 export { PreferenceTemplate } from "./PreferenceTemplate";
 export { PreferenceList } from "./PreferenceList";
-export { PreferencesV4 } from "./PreferencesV4";
+export { PreferencesV4, PreferenceSections } from "./PreferencesV4";
 export { Footer } from "./Footer";
 export { Header } from "./Header";


### PR DESCRIPTION
## Description

We need to integrate `PreferencesV4` into our app, but we have defined several sections for all the preferences, and want to show the section separately. For example, we define two sections: `Organizations` and `Projects`, and want to show Organizations preferences in one page, and Projects preferences in another page. Now I can use 
```
const preferences = usePreferences();
preferences.fetchPreferencePage(tenantId, false);
```
to retrieve all sections, then filter out required section. Now I want to use 
`<PreferenceSections section={section} />`
to integrate it into my app, so need to export `PreferenceSections`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
