### PR TITLE
making archived messages appear to be read regardless of read status

### DIFF
--- a/packages/react-inbox/src/components/Messages2.0/Message.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/Message.tsx
@@ -23,25 +23,25 @@ import { useOnScreen } from "~/hooks/use-on-screen";
 
 import { SlotIcon } from "./pins";
 
-const UnreadIndicator = styled.div<{ read?: IInboxMessagePreview["read"] }>(
-  ({ theme, read }) => {
-    const primaryColor = theme.brand?.colors?.primary;
-
-    return deepExtend(
-      {
-        visibility: read ? "hidden" : "visible",
-        height: "auto",
-        width: 2,
-        background: primaryColor,
-        position: "absolute",
-        left: "1px",
-        top: "1px",
-        bottom: "1px",
-      },
-      theme?.message?.unreadIndicator
-    );
-  }
-);
+const UnreadIndicator = styled.div<{
+  read?: IInboxMessagePreview["read"];
+  archived?: IInboxMessagePreview["archived"];
+}>(({ theme, read, archived }) => {
+  const primaryColor = theme.brand?.colors?.primary;
+  return deepExtend(
+    {
+      visibility: read || archived ? "hidden" : "visible",
+      height: "auto",
+      width: 2,
+      background: primaryColor,
+      position: "absolute",
+      left: "1px",
+      top: "1px",
+      bottom: "1px",
+    },
+    theme?.message?.unreadIndicator
+  );
+});
 
 const ClickableContainer = styled.a(({ theme }) => {
   const primaryColor = theme.brand?.colors?.primary ?? "#9121c2";
@@ -80,6 +80,10 @@ const MessageContainer = styled.div(({ theme }) => {
       },
       "&.archived": {
         filter: "grayscale(100%)",
+        ".icon": {
+          filter: "grayscale(100%)",
+          opacity: "0.3",
+        },
       },
     },
     theme?.message?.container
@@ -190,7 +194,7 @@ const Message: React.FunctionComponent<{
         archived,
       })}
     >
-      <UnreadIndicator read={read} />
+      <UnreadIndicator read={read} archived={archived} />
       {renderedIcon}
       <Contents hasIcon={Boolean(renderedIcon)}>
         {pinDetails &&

--- a/packages/react-inbox/src/components/Messages2.0/actions/index.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/actions/index.tsx
@@ -254,7 +254,7 @@ const MessageActions: React.FunctionComponent<{
         })}
       >
         <TimeAgo>{formattedTime}</TimeAgo>
-        {read && (
+        {read && !archived && (
           <Checkmark
             fill="var(--ci-icon)"
             style={{


### PR DESCRIPTION
## Description

When exposing an archived view, we should make the messages look uniform. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
