### PR TITLE
fixing extra channels and exposing customize on Required topics

### DIFF
--- a/packages/react-hooks/src/preferences/types.ts
+++ b/packages/react-hooks/src/preferences/types.ts
@@ -52,6 +52,7 @@ export interface PreferenceState {
 export type ChannelClassification =
   | "email"
   | "push"
+  | "inbox"
   | "direct_message"
   | "sms"
   | "webhook";


### PR DESCRIPTION
## Description

- When using Customize Delivery Channel, the default would put all options selected even if the defaults had less options.
- When a topic was required, we wouldn't show Customize Delivery Channel at all. Now, we will show it, but not let you de-select all channels.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
