### PR TITLE
fix(refetching): refetch messages when last message is archived, save…

### DIFF
--- a/packages/react-hooks/src/inbox/__tests__/reducer.spec.ts
+++ b/packages/react-hooks/src/inbox/__tests__/reducer.spec.ts
@@ -184,10 +184,13 @@ describe("inbox reducer", () => {
 
         expect(state).toEqual({
           ...initialState,
-          pinned: [],
+          isLoading: false,
           lastMessagesFetched: mockDate,
           messages: [mockGraphMessage],
-          isLoading: false,
+          pinned: [],
+          searchParams: {
+            filters: {},
+          },
         });
       });
 
@@ -216,6 +219,9 @@ describe("inbox reducer", () => {
           lastMessagesFetched: mockDate,
           messages: [mockGraphMessage, mockGraphMessage2],
           isLoading: false,
+          searchParams: {
+            filters: {},
+          },
         });
       });
     });

--- a/packages/react-hooks/src/inbox/reducer.ts
+++ b/packages/react-hooks/src/inbox/reducer.ts
@@ -171,6 +171,7 @@ export default (state: IInbox = initialState, action?: InboxAction): IInbox => {
       return {
         ...state,
         isLoading: false,
+        searchParams: action.meta.searchParams,
         lastMessagesFetched: new Date().getTime(),
         messages: newMessages as IInboxMessagePreview[],
         pinned: action.payload?.appendMessages
@@ -355,6 +356,11 @@ export default (state: IInbox = initialState, action?: InboxAction): IInbox => {
     }
 
     case INBOX_NEW_MESSAGE: {
+      if (state?.searchParams?.archived && !action.payload.archived) {
+        // don't add new message if we are on an archived list
+        return state;
+      }
+
       const newMessage = {
         ...action.payload,
         created: new Date().toISOString(),

--- a/packages/react-hooks/src/inbox/types.ts
+++ b/packages/react-hooks/src/inbox/types.ts
@@ -1,3 +1,4 @@
+import { IGetInboxMessagesParams } from "@trycourier/client-graphql";
 import { Brand, IInboxMessagePreview } from "@trycourier/core";
 import { OnEvent } from "@trycourier/react-provider";
 export interface IInbox<T = IInboxMessagePreview> {
@@ -10,6 +11,7 @@ export interface IInbox<T = IInboxMessagePreview> {
   lastMessagesFetched?: number;
   messages?: Array<T>;
   onEvent?: OnEvent;
+  searchParams?: IGetInboxMessagesParams;
   pinned?: Array<T>;
   startCursor?: string;
   unreadMessageCount?: number;

--- a/packages/react-hooks/src/inbox/use-inbox-actions.ts
+++ b/packages/react-hooks/src/inbox/use-inbox-actions.ts
@@ -56,7 +56,6 @@ export interface IInboxActions {
 
 const useInboxActions = (): IInboxActions => {
   const {
-    tenantId,
     apiUrl,
     authorization,
     clientKey,
@@ -64,6 +63,7 @@ const useInboxActions = (): IInboxActions => {
     dispatch,
     inbox,
     inboxApiUrl,
+    tenantId,
     userId,
     userSignature,
   } =
@@ -262,6 +262,17 @@ const useInboxActions = (): IInboxActions => {
           messageId,
           message,
           event: "archive",
+        });
+      }
+
+      const messageLength = inbox?.messages?.length ?? 0;
+      if (messageLength <= 1 && inbox.searchParams) {
+        dispatch({
+          meta: {
+            searchParams: inbox.searchParams,
+          },
+          payload: () => inboxClient.getMessages(inbox.searchParams),
+          type: "inbox/FETCH_MESSAGES",
         });
       }
     },


### PR DESCRIPTION
… search params

## Description

- save search params so we can refetch
- fetch list again when archived last message
- don't put a new message into the list if we are on the archived view

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
