### PR TITLE
adding pinned to GetInboxMessages

### DIFF
--- a/packages/client-graphql/src/inbox/messages.ts
+++ b/packages/client-graphql/src/inbox/messages.ts
@@ -76,6 +76,7 @@ export type GetInboxMessages = (
       appendMessages: boolean;
       startCursor: string;
       messages: IInboxMessagePreview[];
+      pinned?: IInboxMessagePreview[];
     }
   | undefined
 >;


### PR DESCRIPTION
Pins are always returned from getInboxMessages