### PR TITLE
Bryan/hoist delivery tracking

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -83,7 +83,7 @@ interface ICourierConfig {
   theme?: ProviderTheme;
 
   // handler that runs whenever a route changes.  this is useful for SPA apps to configure a router.push with
-  onRouteChange?: (route: string) => void;
+  onRouteChange?: (route: string, data?: IInboxMessagePreview["data"]) => void;
 
   // intercept function to incercept a message before rendering
   onMessage?: Interceptor;

--- a/packages/components/src/index.tsx
+++ b/packages/components/src/index.tsx
@@ -12,6 +12,7 @@ import { CourierComponents } from "./components";
 import { InboxProps } from "@trycourier/react-inbox";
 import { ToastProps } from "@trycourier/react-toast";
 import { UsePreferences } from "@trycourier/react-hooks";
+import { IInboxMessagePreview } from "@trycourier/core";
 
 const middleware = () => (next) => (action) => {
   const _action =
@@ -78,7 +79,7 @@ interface ICourierConfig {
   enableMutationObserver?: boolean;
   inboxApiUrl?: string;
   theme?: ProviderTheme;
-  onRouteChange?: (route: string) => void;
+  onRouteChange?: (route: string, data?: IInboxMessagePreview["data"]) => void;
   onMessage?: Interceptor;
   components?: {
     inbox?: any;

--- a/packages/react-inbox/src/components/Messages2.0/Message.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/Message.tsx
@@ -121,6 +121,7 @@ const Pinned = styled.div<{ color?: string }>(({ theme, color }) =>
 
 const Message: React.FunctionComponent<{
   actions?: IInboxMessagePreview["actions"];
+  data: IInboxMessagePreview["data"];
   archived?: IInboxMessagePreview["archived"];
   areActionsHovered?: boolean;
   isMessageActive?: boolean;
@@ -139,6 +140,7 @@ const Message: React.FunctionComponent<{
   actions,
   archived,
   areActionsHovered,
+  data,
   isMessageActive,
   messageId,
   openLinksInNewTab,
@@ -175,7 +177,7 @@ const Message: React.FunctionComponent<{
     }
 
     if (courier.onRouteChange) {
-      courier.onRouteChange(action?.href);
+      courier.onRouteChange(action?.href, data);
       return;
     }
 
@@ -410,7 +412,7 @@ const MessageWrapper: React.FunctionComponent<
       }
 
       if (courier.onRouteChange) {
-        courier.onRouteChange(clickActionDetails?.href);
+        courier.onRouteChange(clickActionDetails?.href, data);
         return;
       }
 
@@ -428,6 +430,7 @@ const MessageWrapper: React.FunctionComponent<
         actions={actions}
         archived={archived}
         areActionsHovered={areActionsHovered}
+        data={data}
         isMessageActive={isMessageFocused || isMessageHovered}
         messageId={messageId}
         openLinksInNewTab={openLinksInNewTab}
@@ -455,6 +458,7 @@ const MessageWrapper: React.FunctionComponent<
     renderedIcon,
     renderPin,
     title,
+    data,
   ]);
 
   return (

--- a/packages/react-inbox/src/components/Messages2.0/index.tsx
+++ b/packages/react-inbox/src/components/Messages2.0/index.tsx
@@ -289,7 +289,7 @@ const Messages: React.ForwardRefExoticComponent<
 
     useEffect(() => {
       fetchRecipientPreferences(tenantId);
-    }, []);
+    }, [tenantId]);
 
     const handleCloseInbox = (event: React.MouseEvent) => {
       event.preventDefault();

--- a/packages/react-provider/src/hooks/use-listen-for-transport.ts
+++ b/packages/react-provider/src/hooks/use-listen-for-transport.ts
@@ -1,0 +1,29 @@
+import { IInboxMessagePreview } from "@trycourier/core";
+import { ICourierContext, useCourier } from "..";
+import { useEffect } from "react";
+
+export const useListenForTransportEvent = ({
+  transport,
+}: {
+  transport: ICourierContext["transport"];
+}) => {
+  const { createTrackEvent } = useCourier();
+
+  useEffect(() => {
+    if (!transport) {
+      return;
+    }
+
+    transport.listen({
+      id: "websocket-delivery-listener",
+      type: "message",
+      listener: (courierEvent) => {
+        const courierMessage = courierEvent?.data as IInboxMessagePreview;
+        const courierData = courierMessage?.data;
+        if (courierData?.trackingIds?.deliverTrackingId) {
+          createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
+        }
+      },
+    });
+  }, [transport]);
+};

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -36,6 +36,7 @@ import deepExtend from "deep-extend";
 import { darkVariables, lightVariables } from "./theme";
 import { createGlobalStyle } from "styled-components";
 import { useIsOnline } from "./hooks/use-is-online";
+import { useListenForTransportEvent } from "./hooks/use-listen-for-transport";
 
 export * from "./hooks";
 
@@ -271,6 +272,8 @@ const CourierProviderInner: React.FunctionComponent<
       })
     );
   }, [state.brand, clientKey, userId, state.localStorage]);
+
+  useListenForTransportEvent({ transport });
 
   return (
     <CourierContext.Provider

--- a/packages/react-provider/src/types.ts
+++ b/packages/react-provider/src/types.ts
@@ -34,7 +34,7 @@ export interface ICourierProviderProps {
   inboxApiUrl?: string;
   localStorage?: Storage;
   onMessage?: Interceptor;
-  onRouteChange?: (route: string) => void;
+  onRouteChange?: (route: string, data?: IInboxMessagePreview["data"]) => void;
   tenantId?: string;
   theme?: ProviderTheme;
   transport?: CourierTransport;

--- a/packages/react-toast/src/components/Body/index.tsx
+++ b/packages/react-toast/src/components/Body/index.tsx
@@ -67,8 +67,19 @@ const Body: React.FunctionComponent<
     onClick?: (event: React.MouseEvent) => void;
     title?: IInboxMessagePreview["title"] | ReactElement;
     preview?: IInboxMessagePreview["preview"] | ReactElement;
+    additional_data: IInboxMessagePreview["data"];
   }
-> = ({ title, preview, actions, icon, data, onClick, messageId, ...props }) => {
+> = ({
+  title,
+  preview,
+  actions,
+  icon,
+  data,
+  additional_data,
+  onClick,
+  messageId,
+  ...props
+}) => {
   const courier = useCourier();
   const [, { config }] = useToast();
 
@@ -152,7 +163,7 @@ const Body: React.FunctionComponent<
       }
 
       if (courier.onRouteChange) {
-        courier.onRouteChange(clickActionDetails?.href);
+        courier.onRouteChange(clickActionDetails?.href, additional_data);
         return;
       }
 
@@ -181,7 +192,7 @@ const Body: React.FunctionComponent<
       }
 
       if (courier.onRouteChange) {
-        courier.onRouteChange(action?.href);
+        courier.onRouteChange(action?.href, additional_data);
         return;
       }
 

--- a/packages/react-toast/src/components/Toast/index.tsx
+++ b/packages/react-toast/src/components/Toast/index.tsx
@@ -44,6 +44,8 @@ export const Toast: React.FunctionComponent<IToastConfig> = (props) => {
       toast(
         <Body
           {...message}
+          // toast() uses the data props, use additional_data
+          additional_data={message?.data || {}}
           icon={
             typeof message?.icon === "string"
               ? message.icon

--- a/packages/react-toast/src/components/index.tsx
+++ b/packages/react-toast/src/components/index.tsx
@@ -46,7 +46,7 @@ export const ToastBody: React.FunctionComponent<
         >
           <div className="Toastify__toast Toastify__toast--default">
             <div className="Toastify__toast-body">
-              <Body {...props} />
+              <Body {...props} additional_data={props.data || {}} />
             </div>
             <div
               className="Toastify__progress-bar Toastify__progress-bar--animated Toastify__progress-bar--default"

--- a/packages/react-toast/src/hooks/index.ts
+++ b/packages/react-toast/src/hooks/index.ts
@@ -29,8 +29,6 @@ export const useListenForTransportEvent = ({
   transport: ICourierContext["transport"];
   handleToast;
 }) => {
-  const { createTrackEvent } = useCourier();
-
   useEffect(() => {
     if (!transport) {
       return;
@@ -40,12 +38,6 @@ export const useListenForTransportEvent = ({
       id: "toast-listener",
       type: "message",
       listener: (courierEvent) => {
-        const courierMessage = courierEvent?.data as IInboxMessagePreview;
-        const courierData = courierMessage?.data;
-        if (courierData?.trackingIds?.deliverTrackingId) {
-          createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
-        }
-
         handleToast(courierEvent?.data);
       },
     });


### PR DESCRIPTION
## Description

Allows Delivered events to be sent with only CourierProvider and not Toast

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

