### PR TITLE
hoisting createTrackEvent(deliveryTrackingId)

### DIFF
--- a/packages/react-provider/src/hooks/use-listen-for-transport.ts
+++ b/packages/react-provider/src/hooks/use-listen-for-transport.ts
@@ -1,0 +1,29 @@
+import { IInboxMessagePreview } from "@trycourier/core";
+import { ICourierContext, useCourier } from "..";
+import { useEffect } from "react";
+
+export const useListenForTransportEvent = ({
+  transport,
+}: {
+  transport: ICourierContext["transport"];
+}) => {
+  const { createTrackEvent } = useCourier();
+
+  useEffect(() => {
+    if (!transport) {
+      return;
+    }
+
+    transport.listen({
+      id: "websocket-delivery-listener",
+      type: "message",
+      listener: (courierEvent) => {
+        const courierMessage = courierEvent?.data as IInboxMessagePreview;
+        const courierData = courierMessage?.data;
+        if (courierData?.trackingIds?.deliverTrackingId) {
+          createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
+        }
+      },
+    });
+  }, [transport]);
+};

--- a/packages/react-provider/src/hooks/use-listen-for-transport.ts
+++ b/packages/react-provider/src/hooks/use-listen-for-transport.ts
@@ -1,13 +1,14 @@
 import { IInboxMessagePreview } from "@trycourier/core";
-import { ICourierContext, useCourier } from "..";
+import { ICourierContext } from "..";
 import { useEffect } from "react";
 
 export const useListenForTransportEvent = ({
   transport,
+  createTrackEvent,
 }: {
   transport: ICourierContext["transport"];
+  createTrackEvent: (trackingId: string) => void;
 }) => {
-  const { createTrackEvent } = useCourier();
 
   useEffect(() => {
     if (!transport) {
@@ -25,5 +26,5 @@ export const useListenForTransportEvent = ({
         }
       },
     });
-  }, [transport]);
+  }, [createTrackEvent, transport]);
 };

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -273,7 +273,10 @@ const CourierProviderInner: React.FunctionComponent<
     );
   }, [state.brand, clientKey, userId, state.localStorage]);
 
-  useListenForTransportEvent({ transport });
+  useListenForTransportEvent({
+    transport,
+    createTrackEvent: actions.createTrackEvent,
+  });
 
   return (
     <CourierContext.Provider

--- a/packages/react-provider/src/index.tsx
+++ b/packages/react-provider/src/index.tsx
@@ -36,6 +36,7 @@ import deepExtend from "deep-extend";
 import { darkVariables, lightVariables } from "./theme";
 import { createGlobalStyle } from "styled-components";
 import { useIsOnline } from "./hooks/use-is-online";
+import { useListenForTransportEvent } from "./hooks/use-listen-for-transport";
 
 export * from "./hooks";
 
@@ -271,6 +272,8 @@ const CourierProviderInner: React.FunctionComponent<
       })
     );
   }, [state.brand, clientKey, userId, state.localStorage]);
+
+  useListenForTransportEvent({ transport });
 
   return (
     <CourierContext.Provider

--- a/packages/react-toast/src/hooks/index.ts
+++ b/packages/react-toast/src/hooks/index.ts
@@ -29,8 +29,6 @@ export const useListenForTransportEvent = ({
   transport: ICourierContext["transport"];
   handleToast;
 }) => {
-  const { createTrackEvent } = useCourier();
-
   useEffect(() => {
     if (!transport) {
       return;
@@ -40,12 +38,6 @@ export const useListenForTransportEvent = ({
       id: "toast-listener",
       type: "message",
       listener: (courierEvent) => {
-        const courierMessage = courierEvent?.data as IInboxMessagePreview;
-        const courierData = courierMessage?.data;
-        if (courierData?.trackingIds?.deliverTrackingId) {
-          createTrackEvent(courierData?.trackingIds?.deliverTrackingId);
-        }
-
         handleToast(courierEvent?.data);
       },
     });

--- a/packages/react-toast/src/hooks/index.ts
+++ b/packages/react-toast/src/hooks/index.ts
@@ -2,7 +2,6 @@ import { ICourierContext, useCourier } from "@trycourier/react-provider";
 import { useEffect } from "react";
 import { IToastConfig } from "../types";
 import { UseToast, ToastCaller } from "./types";
-import { IInboxMessagePreview } from "@trycourier/core";
 
 export const useToast: UseToast = () => {
   const { toast, clientKey } =


### PR DESCRIPTION
## Description

Hoisting delivery tracking to CourierProvider from Toast; currently the docs already says this, but the listener is only attached when using Toast.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

