### PR TITLE
chore: upgrade markdown-to-jsx to latest version

### DIFF
--- a/packages/react-inbox-next/package.json
+++ b/packages/react-inbox-next/package.json
@@ -26,7 +26,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.19.0",
     "deep-extend": "^0.6.0",
-    "markdown-to-jsx": "7.1.7",
+    "markdown-to-jsx": "^7.7.3",
     "react-loading-skeleton": "^2.2.0",
     "rimraf": "^3.0.2"
   },

--- a/packages/react-inbox/package.json
+++ b/packages/react-inbox/package.json
@@ -26,7 +26,7 @@
     "classnames": "^2.2.6",
     "date-fns": "^2.19.0",
     "deep-extend": "^0.6.0",
-    "markdown-to-jsx": "7.1.7",
+    "markdown-to-jsx": "^7.7.3",
     "react-intersection-observer": "^9.4.0",
     "react-loading-skeleton": "^2.2.0",
     "rimraf": "^3.0.2",

--- a/packages/react-toast/package.json
+++ b/packages/react-toast/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@trycourier/react-hooks": "^6.4.0",
     "deep-extend": "^0.6.0",
-    "markdown-to-jsx": "7.1.7",
+    "markdown-to-jsx": "^7.7.3",
     "react-toastify": "^9.1.3",
     "rimraf": "^3.0.2",
     "tinycolor2": "^1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14220,11 +14220,6 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
-markdown-to-jsx@7.1.7:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz#a5f22102fb12241c8cea1ca6a4050bb76b23a25d"
-  integrity sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==
-
 markdown-to-jsx@^6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz#b4528b1ab668aef7fe61c1535c27e837819392c5"
@@ -14232,6 +14227,11 @@ markdown-to-jsx@^6.11.4:
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"
+
+markdown-to-jsx@^7.7.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.7.3.tgz#c75927252592696e9e8b2a9557628749d8ab023e"
+  integrity sha512-o35IhJDFP6Fv60zPy+hbvZSQMmgvSGdK5j8NRZ7FeZMY+Bgqw+dSg7SC1ZEzC26++CiOUCqkbq96/c3j/FfTEQ==
 
 material-colors@^1.2.1:
   version "1.2.6"


### PR DESCRIPTION
## Description

Updating markdown-to-jsx to 7.7.3 due to Cross-Site Scripting vulnerability.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://github.com/trycourier/courier-react/issues/604
