### PR TITLE
chore: bump jwt-decode to 4.0.0

### DIFF
--- a/packages/react-hooks/src/use-transport.ts
+++ b/packages/react-hooks/src/use-transport.ts
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useEffect } from "react";
 import { CourierTransport, TransportOptions } from "@trycourier/transport";
-import jwtDecode from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 interface DecodedAuth {
   scope: string;
   tenantId: string;

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -20,7 +20,7 @@
     "@trycourier/courier-js": "^1.4.2",
     "@trycourier/transport": "^6.4.1",
     "buffer": "^6.0.3",
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "^4.0.0",
     "react-use": "^17.2.1",
     "rimraf": "^3.0.2",
     "urql": "^2.0.1",

--- a/packages/react-provider/src/hooks/use-client-source-id.ts
+++ b/packages/react-provider/src/hooks/use-client-source-id.ts
@@ -1,6 +1,6 @@
 import * as uuid from "uuid";
 import { useMemo } from "react";
-import jwtDecode from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 
 const useClientSourceId = ({
   clientKey,

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@trycourier/core": "^6.4.1",
-    "jwt-decode": "^3.1.2",
+    "jwt-decode": "^4.0.0",
     "reconnecting-websocket": "^4.4.0",
     "rimraf": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -13454,6 +13454,11 @@ jwt-decode@^3.1.2:
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
   integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"


### PR DESCRIPTION
## Description

This will generate a major update as `jwt-decode:4.0.0` drops support for node 14 and 16 and requires 18 as minimum. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

