### PR TITLE
chore: bump actions/cache to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - run: echo "::set-output name=dir::$(yarn cache dir)"
         id: yarn-cache-dir-path
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
## Description

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions.

[NOT a breaking-change](https://github.com/marketplace/actions/cache#:~:text=Changes%20in%20these%20release%20are%20fully%20backward%20compatible.). 

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix [#1](https://github.com/trycourier/courier-react/actions/runs/13653824653/job/38168229202?pr=621)
