### PR TITLE
fix: add missing jwt-decode package

### DIFF
--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -23,6 +23,7 @@
     "@trycourier/client-graphql": "^7.1.0",
     "@trycourier/core": "^7.1.0",
     "deep-extend": "^0.6.0",
+    "jwt-decode": "^4.0.0",
     "rimraf": "^5.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

The `jwt-decode` library is imported in the `react-hooks` package.
However, the library isn't added to the package's package.json file.

```
 TypeError: (0 , _jwtDecode.jwtDecode) is not a function...
```
This change adds the `jwt-decode` library to the `react-hooks` package.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
