### PR TITLE
fix(use transiet prop): use styled-component transiet prop to prevent…

### DIFF
--- a/packages/react-hooks/src/inbox/reducer.ts
+++ b/packages/react-hooks/src/inbox/reducer.ts
@@ -179,7 +179,7 @@ export default (state: IInbox = initialState, action?: InboxAction): IInbox => {
       return {
         ...state,
         isLoading: false,
-        searchParams: action.meta.searchParams,
+        searchParams: action.meta?.searchParams,
         lastMessagesFetched: new Date().getTime(),
         messages: newMessagesFiltered as IInboxMessagePreview[],
         pinned: action.payload?.appendMessages

--- a/packages/react-inbox/src/components/Inbox/Bell.tsx
+++ b/packages/react-inbox/src/components/Inbox/Bell.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import deepExtend from "deep-extend";
 
-const bellStyles = ({ isOpen, theme }) =>
+const bellStyles = ({ $isOpen, theme }) =>
   deepExtend(
     {
       cursor: "pointer",
@@ -13,7 +13,7 @@ const bellStyles = ({ isOpen, theme }) =>
       outline: "none",
       display: "inline-block",
       path: {
-        fill: isOpen
+        fill: $isOpen
           ? theme?.icon?.open ?? theme?.brand?.colors?.primary ?? "#9121c2"
           : theme?.icon?.closed ?? theme?.brand?.colors?.secondary ?? "#C1B6DD",
       },
@@ -21,7 +21,7 @@ const bellStyles = ({ isOpen, theme }) =>
     theme.icon
   );
 
-export const Bell = styled.div<{ isOpen: boolean }>(bellStyles);
+export const Bell = styled.div<{ $isOpen: boolean }>(bellStyles);
 
 const BellSvg: React.FunctionComponent = () => {
   return (

--- a/packages/react-inbox/src/components/Inbox/index.tsx
+++ b/packages/react-inbox/src/components/Inbox/index.tsx
@@ -210,7 +210,7 @@ const Inbox: React.FunctionComponent<InboxProps> = (props) => {
         aria-pressed={isOpen}
         data-testid="bell"
         className={`inbox-bell ${props.className ?? ""}`}
-        isOpen={isOpen ?? false}
+        $isOpen={isOpen ?? false}
         onClick={handleIconOnClick}
         onKeyDown={handleIconOnKeyDown}
         role="button"


### PR DESCRIPTION
… issues with users on v6

## Description

version 6 of styled components doesn't automatically filter out props anymore, so people on v6 were getting an error.  we can use transient props to solve this

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/trycourier/courier-react/issues/605
