### PR TITLE
fix: ensure preference experience page will show digest time in browser timezone

### DIFF
--- a/packages/react-preferences/package.json
+++ b/packages/react-preferences/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@trycourier/react-hooks": "^7.3.0",
     "date-fns": "^2.19.0",
+    "date-fns-tz": "^2.0.0",
     "react-toggle": "^4.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8612,6 +8612,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns-tz@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-2.0.1.tgz#0a9b2099031c0d74120b45de9fd23192e48ea495"
+  integrity sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==
+
 date-fns@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.19.0.tgz#65193348635a28d5d916c43ec7ce6fbd145059e1"


### PR DESCRIPTION
## Description

- The idea of this PR is to make sure digest schedule date, into Notification Preferences page, will be reflecting the user browser timezone. 

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> `Fix [#1]()`
