### PR TITLE
fix: propagate GraphQL errors from updateRecipientPreferences (SUP-561)

### DIFF
--- a/packages/client-graphql/src/preferences.ts
+++ b/packages/client-graphql/src/preferences.ts
@@ -168,7 +168,7 @@ export const updateRecipientPreferences =
       return Promise.resolve();
     }
 
-    await client
+    const results = await client
       .mutation(UPDATE_RECIPIENT_PREFERENCES, {
         id: payload.templateId,
         preferences: {
@@ -180,6 +180,10 @@ export const updateRecipientPreferences =
         accountId: payload.tenantId,
       })
       .toPromise();
+
+    if (results.error) {
+      throw results.error;
+    }
 
     return payload;
   };

--- a/packages/react-hooks/src/preferences/reducer.ts
+++ b/packages/react-hooks/src/preferences/reducer.ts
@@ -56,12 +56,21 @@ export default (state: PreferenceState = initialState, action) => {
       return {
         ...state,
         isUpdating: false,
+        error: undefined,
         recipientPreferences: state.recipientPreferences?.map((preference) => {
           if (preference.templateId === action?.payload?.templateId) {
             return action?.payload;
           }
           return preference;
         }),
+      };
+    }
+
+    case "preferences/UPDATE_RECIPIENT_PREFERENCES/ERROR": {
+      return {
+        ...state,
+        isUpdating: false,
+        error: action?.ex,
       };
     }
   }

--- a/packages/react-hooks/src/preferences/types.ts
+++ b/packages/react-hooks/src/preferences/types.ts
@@ -48,6 +48,7 @@ export type PreferenceSection = {
 };
 
 export interface PreferenceState {
+  error?: Error;
   isLoading?: boolean;
   isUpdating?: boolean;
   preferences?: IPreferenceTemplate[];


### PR DESCRIPTION
## Summary

- **client-graphql**: `updateRecipientPreferences` now checks `results.error` from the GraphQL mutation and throws instead of silently swallowing errors.
- **react-hooks**: Added `UPDATE_RECIPIENT_PREFERENCES/ERROR` case to the preferences reducer, which clears `isUpdating` and surfaces the error in state. Added `error` field to `PreferenceState` type.
- Companion to backend fix: https://github.com/trycourier/backend/pull/9319

## Test plan

- [ ] Verify existing preference update flows still work (status, routing, digest schedule)
- [ ] Verify that a backend GraphQL error now surfaces in the SDK instead of being silently ignored
- [ ] Verify `isUpdating` resets to `false` on error


Made with [Cursor](https://cursor.com)